### PR TITLE
Defer internalUrl resolution until the publish task is run

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ subprojects {
          */
         maven {
           name = "internal"
-          url = URI(providers.gradleProperty("internalUrl").get())
+          setUrl(providers.gradleProperty("internalUrl"))
           credentials(PasswordCredentials::class)
         }
       }


### PR DESCRIPTION
When I configured the project to publish to an internal Maven repo, I was copy-pasting from other projects like Paparazzi that do this in their `build.gradle`:
```
maven {
  name = "internal"
  url = providers.gradleProperty("internalUrl")
  credentials(PasswordCredentials)
}
```

The `url` is backed by a provider, which doesn't get queried until the task runs. So if you don't have an `internalUrl` property set it will fail to publish, but won't block anything else.

The version I wrote in the `build.gradle.kts` behaved differently:
```
maven {
  name = "internal"
  url = URI(providers.gradleProperty("internalUrl").get())
  credentials(PasswordCredentials::class)
}
```

In this version, the `url` is queried at configuration time, so if you don't have an `internalUrl` set you can't sync the project. I'm switching to what I _think_ is a provider approach equivalent to what we use elsewhere.

This should hopefully address this issue:
- https://github.com/squareup/gingham/issues/2