### PR TITLE
Close `File`-based input stream

### DIFF
--- a/plugin/src/main/java/com/squareup/cash/gingham/plugin/ResourceParser.kt
+++ b/plugin/src/main/java/com/squareup/cash/gingham/plugin/ResourceParser.kt
@@ -14,7 +14,7 @@ import javax.xml.parsers.DocumentBuilderFactory
  * Ignores all other resources, including <plurals> and <string-array>.
  */
 internal fun parseResources(file: File): List<RawResource> =
-  parseResources(file.inputStream())
+  file.inputStream().use(::parseResources)
 
 /**
  * Parses and returns all of the Android <string> resources declared in the given stream.


### PR DESCRIPTION
The `DocumentBuilder` API is not documented to have to close this. The default implementation does close it in a try/finally, but adding this safety measure just in case.