### PR TITLE
Spotless 6.13 and Ktlint 0.48.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,26 +20,11 @@ plugins {
 configure<SpotlessExtension> {
   kotlin {
     target("src/**/*.kt")
+    ktlint(libs.versions.ktlint.get())
     licenseHeader("// Copyright Square, Inc.")
-    // ktlint doesn't honour .editorconfig yet: https://github.com/diffplug/spotless/issues/142
-    ktlint("0.41.0").userData(
-      mapOf(
-        "insert_final_newline" to "true",
-        "end_of_line" to "lf",
-        "charset" to "utf-8",
-        "indent_size" to "2",
-      )
-    )
   }
   kotlinGradle {
-    ktlint("0.41.0").userData(
-      mapOf(
-        "insert_final_newline" to "true",
-        "end_of_line" to "lf",
-        "charset" to "utf-8",
-        "indent_size" to "2",
-      )
-    )
+    ktlint(libs.versions.ktlint.get())
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,8 @@ junit = "4.13.2"
 kotlin = "1.7.10"
 kotlinPoet = "1.12.0"
 mavenPublish = "0.22.0"
-spotless = "6.11.0"
+spotless = "6.13.0"
+ktlint = "0.48.1"
 truth = "1.1.3"
 
 [libraries]


### PR DESCRIPTION
Spotless allows ktlint to read editorconfig properly now.