### PR TITLE
Use 'variant' terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Build the module:
 ./gradlew my-app:build
 ```
 
-Or run the Gingham gradle task for the relevant build flavor:
+Or run the Gingham gradle task for the relevant variant:
 
 ```shell
 ./gradlew my-app:generateFormattedResourcesDebug


### PR DESCRIPTION
There's build types and product flavors and the combination of those is called a variant. Not sure to what degree developers understand the difference, but at least "variant" is a normal word describing variations so it's still understandable even if you don't know it's an AGP term-of-art.