### PR TITLE
Remove explicitly set default values

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -13,15 +13,6 @@ android {
     minSdk = 24
     targetSdk = 33
   }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
-
-  kotlinOptions {
-    jvmTarget = "1.8"
-  }
 }
 
 dependencies {

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -27,13 +27,6 @@ android {
 
   compileOptions {
     isCoreLibraryDesugaringEnabled = true
-
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
-
-  kotlinOptions {
-    jvmTarget = "1.8"
   }
 }
 

--- a/sample/library/build.gradle.kts
+++ b/sample/library/build.gradle.kts
@@ -13,13 +13,4 @@ android {
     minSdk = 24
     targetSdk = 33
   }
-
-  compileOptions {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
-  }
-
-  kotlinOptions {
-    jvmTarget = "1.8"
-  }
 }


### PR DESCRIPTION
- Kotlin 1.7.0 and newer targets JVM 1.8 bytecode by default per https://kotlinlang.org/docs/whatsnew17.html#removed-jvm-target-version-1-6.
- AGP 4.2.0 and newer targets JVM 1.8 bytecode by defualt per https://developer.android.com/studio/past-releases/past-agp-releases/agp-4-2-0-release-notes#java-8-default.