### PR TITLE
Convert instant to epoch millis instead of Date

### DIFF
--- a/plugin/src/main/java/app/cash/gingham/plugin/ResourceWriter.kt
+++ b/plugin/src/main/java/app/cash/gingham/plugin/ResourceWriter.kt
@@ -18,7 +18,6 @@ import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.asClassName
 import com.squareup.kotlinpoet.buildCodeBlock
 import java.time.Instant
-import java.util.Date
 
 /**
  * Writes the given tokenized resources to a Kotlin source file.
@@ -102,7 +101,7 @@ private fun Token.toParameterSpec(): ParameterSpec =
 
 private fun Token.toParameterCodeBlock(): CodeBlock =
   when (type) {
-    Instant::class -> CodeBlock.of("%T.from(%L)", Date::class, parameterName)
+    Instant::class -> CodeBlock.of("%L.toEpochMilli()", parameterName)
     else -> CodeBlock.of("%L", parameterName)
   }
 


### PR DESCRIPTION
Formatting result will be the same (as validated by the tests), and this saves allocation/memory size since `Date` is larger than a boxed `Long`.