### PR TITLE
Convert FormattedResource to manual equals/hashCode/toString

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -17,4 +17,7 @@ android {
 
 dependencies {
   api(libs.androidAnnotation)
+
+  testImplementation(libs.junit)
+  testImplementation(libs.truth)
 }

--- a/runtime/src/main/java/app/cash/gingham/FormattedResource.kt
+++ b/runtime/src/main/java/app/cash/gingham/FormattedResource.kt
@@ -27,7 +27,47 @@ import androidx.annotation.StringRes
  *
  * @property arguments Arguments passed directly to [MessageFormat.format].
  */
-data class FormattedResource constructor(
+class FormattedResource constructor(
   @StringRes val id: Int,
   val arguments: Any,
-)
+) {
+
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other !is FormattedResource) return false
+
+    return id == other.id &&
+      arguments.flexibleEquals(other.arguments)
+  }
+
+  /**
+   * Returns [Array.contentEquals] if this and [other] are both arrays, otherwise uses `==`.
+   */
+  private fun Any.flexibleEquals(other: Any?): Boolean {
+    return this == other || (this is Array<*> && other is Array<*> && contentEquals(other))
+  }
+
+  override fun hashCode(): Int {
+    var result = id
+    result = 31 * result + arguments.flexibleHashCode()
+    return result
+  }
+
+  /**
+   * Returns [Array.contentHashCode] if this is an array, otherwise [hashCode].
+   */
+  private fun Any.flexibleHashCode(): Int {
+    return if (this is Array<*>) contentHashCode() else hashCode()
+  }
+
+  override fun toString(): String {
+    return "FormattedResource(id=$id, arguments=${arguments.flexibleToString()}"
+  }
+
+  /**
+   * Returns [Array.contentToString] if this is an array, otherwise [toString].
+   */
+  private fun Any.flexibleToString(): String {
+    return if (this is Array<*>) contentToString() else toString()
+  }
+}

--- a/runtime/src/test/java/app/cash/gingham/FormattedResourceTest.kt
+++ b/runtime/src/test/java/app/cash/gingham/FormattedResourceTest.kt
@@ -1,0 +1,105 @@
+package app.cash.gingham
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class FormattedResourceTest {
+  //region equals
+  @Test fun `equals same instance returns true`() {
+    val instance = FormattedResource(id = 123, arguments = intArrayOf(1, 2))
+    @Suppress("KotlinConstantConditions")
+    assertThat(instance == instance).isTrue()
+  }
+
+  @Test fun `equals instance of different class returns false`() {
+    val instance = FormattedResource(id = 123, arguments = 1)
+    assertThat(instance.equals(listOf("a"))).isFalse()
+  }
+
+  @Test fun `equals with different ids returns false`() {
+    val a = FormattedResource(id = 123, arguments = mapOf("a" to 1, "b" to 2))
+    val b = FormattedResource(id = 321, arguments = mapOf("a" to 1, "b" to 2))
+    assertThat(a == b).isFalse()
+    assertThat(b == a).isFalse()
+  }
+
+  @Test fun `equals with different argument maps returns false`() {
+    val a = FormattedResource(id = 123, arguments = mapOf("a" to 1, "b" to 2))
+    val b = FormattedResource(id = 123, arguments = mapOf("a" to 3, "b" to 4))
+    assertThat(a == b).isFalse()
+    assertThat(b == a).isFalse()
+  }
+
+  @Test fun `equals with same ids and argument maps returns true`() {
+    val a = FormattedResource(id = 123, arguments = mapOf("a" to 1, "b" to 2))
+    val b = FormattedResource(id = 123, arguments = mapOf("a" to 1, "b" to 2))
+    assertThat(a == b).isTrue()
+    assertThat(b == a).isTrue()
+  }
+
+  @Test fun `equals with different argument arrays returns false`() {
+    val a = FormattedResource(id = 123, arguments = arrayOf("a", "b"))
+    val b = FormattedResource(id = 123, arguments = arrayOf("c", "d"))
+    assertThat(a == b).isFalse()
+    assertThat(b == a).isFalse()
+  }
+
+  @Test fun `equals with only one argument array returns false`() {
+    val a = FormattedResource(id = 123, arguments = arrayOf("a", "b"))
+    val b = FormattedResource(id = 123, arguments = "cd")
+    assertThat(a == b).isFalse()
+    assertThat(b == a).isFalse()
+  }
+
+  @Test fun `equals with same ids and argument arrays returns true`() {
+    val a = FormattedResource(id = 123, arguments = arrayOf("a", "b"))
+    val b = FormattedResource(id = 123, arguments = arrayOf("a", "b"))
+    assertThat(a == b).isTrue()
+    assertThat(b == a).isTrue()
+  }
+  //endregion
+
+  //region hashCode
+  @Test fun `hashCode with different ids returns different values`() {
+    val a = FormattedResource(id = 123, arguments = mapOf("a" to 1, "b" to 2))
+    val b = FormattedResource(id = 321, arguments = mapOf("a" to 1, "b" to 2))
+    assertThat(a.hashCode()).isNotEqualTo(b.hashCode())
+  }
+
+  @Test fun `hashCode with different argument maps returns different values`() {
+    val a = FormattedResource(id = 123, arguments = mapOf("a" to 1, "b" to 2))
+    val b = FormattedResource(id = 123, arguments = mapOf("a" to 3, "b" to 4))
+    assertThat(a.hashCode()).isNotEqualTo(b.hashCode())
+  }
+
+  @Test fun `hashCode with same ids and argument maps returns same values`() {
+    val a = FormattedResource(id = 123, arguments = mapOf("a" to 1, "b" to 2))
+    val b = FormattedResource(id = 123, arguments = mapOf("a" to 1, "b" to 2))
+    assertThat(a.hashCode()).isEqualTo(b.hashCode())
+  }
+
+  @Test fun `hashCode with different argument arrays returns different values`() {
+    val a = FormattedResource(id = 123, arguments = arrayOf("a", "b"))
+    val b = FormattedResource(id = 123, arguments = arrayOf("c", "d"))
+    assertThat(a.hashCode()).isNotEqualTo(b.hashCode())
+  }
+
+  @Test fun `hashCode with same ids and argument arrays returns same values`() {
+    val a = FormattedResource(id = 123, arguments = arrayOf("a", "b"))
+    val b = FormattedResource(id = 123, arguments = arrayOf("a", "b"))
+    assertThat(a.hashCode()).isEqualTo(b.hashCode())
+  }
+  //endregion
+
+  //region toString
+  @Test fun `toString with map includes contents`() {
+    val instance = FormattedResource(id = 123, arguments = mapOf("a" to 1, "b" to 2))
+    assertThat(instance.toString()).isEqualTo("FormattedResource(id=123, arguments={a=1, b=2}")
+  }
+
+  @Test fun `toString with array includes contents`() {
+    val instance = FormattedResource(id = 123, arguments = arrayOf("a", "b"))
+    assertThat(instance.toString()).isEqualTo("FormattedResource(id=123, arguments=[a, b]")
+  }
+  //endregion
+}


### PR DESCRIPTION
Addresses [my own comment](https://github.com/squareup/gingham/issues/4#issuecomment-1401156732) on #4.

In #42, `FormattedResource` was changed in order to sometimes accept arguments in an array rather than a map. Kotlin data classes do not use array contents in their generated functions, so this change breaks consumer equality checks, which are probably important in some use cases. This PR updates `FormattedResource` to check array contents when an array is used.

I'll add tests to this PR if the premise is accepted.

I also removed the `data` keyword because I assume we don't care to ship `copy` and `component` functions, but I can restore it if I'm wrong about that.

Also happy to make the helper functions `inline` or tweak anything else if performance is a concern.