### PR TITLE
Add Square copyright profile, on by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # IntelliJ IDEA
-.idea
+.idea/*
+!.idea/copyright
 
 # Gradle
 .gradle

--- a/.idea/copyright/Square.xml
+++ b/.idea/copyright/Square.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Copyright Square, Inc." />
+    <option name="myName" value="Square" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,8 @@
+<component name="CopyrightManager">
+  <settings default="Square">
+    <LanguageOptions name="__TEMPLATE__">
+      <option name="addBlankAfter" value="false" />
+      <option name="block" value="false" />
+    </LanguageOptions>
+  </settings>
+</component>


### PR DESCRIPTION
This adds the Square copyright notice to each new file automatically, as mentioned in the comments of #53. `<option name="addBlankAfter" value="false" />` does what it sounds like, so this should also be compatible with the Spotless rules.

The notice is also added to files that might not need them, like new build.gradle.kts files when a new module is added. Do we care? I can't find a way to disable this.

Possibly related: I notice the generated `profiles_settings.xml` looks a bit different than [Redwood's](https://github.com/cashapp/redwood/blob/trunk/.idea/copyright/profiles_settings.xml). Perhaps it was applied a different way in the IDE settings UI?