### PR TITLE
Map SpellOut arguments to Number instead of Int

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceMerger.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceMerger.kt
@@ -59,10 +59,10 @@ internal fun mergeResources(
     }
     val argumentType = when (token.type) {
       None -> Any::class
-      Number -> KotlinNumber::class
+      Number, SpellOut -> KotlinNumber::class
       Date, Time -> Instant::class
       Duration -> KotlinDuration::class
-      Choice, Ordinal, Plural, SelectOrdinal, SpellOut -> Int::class
+      Choice, Ordinal, Plural, SelectOrdinal -> Int::class
       Select -> String::class
     }
     MergedResource.Argument(


### PR DESCRIPTION
SpellOut arguments seem to work with floating point numbers as well.

If you do:
```kotlin
println(MessageFormat.format("{0, spellout}", 123.456))
```

You get:
```
one hundred twenty-three point four five six
```