### PR TITLE
Only do branch builds on manual dispatch from web UI

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,11 +2,7 @@ name: build
 
 on:
   pull_request: {}
-  push:
-    branches:
-      - '**'
-    tags-ignore:
-      - '**'
+  workflow_dispatch: {}
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"


### PR DESCRIPTION
Save some CI time. Branch builds are useful when testing _before_ creating a PR. I'm honestly not sure if this works how I want or not, but we'll see.