### PR TITLE
Publish snapshot from 'main'

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,11 @@ name: build
 on:
   pull_request: {}
   workflow_dispatch: {}
+  push:
+    branches:
+      - 'main'
+    tags-ignore:
+      - '**'
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
@@ -26,6 +31,12 @@ jobs:
         with:
           api-level: 24
           script: ./gradlew :tests:connectedCheck
+
+      - run: ./gradlew publish
+        if: ${{ github.ref == 'refs/heads/main' && github.repository == 'cashapp/paraphrase' }}
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
 
       - name: Deploy docs to website
         if: ${{ github.ref == 'refs/heads/main' && github.repository == 'cashapp/paraphrase' }}


### PR DESCRIPTION
Also restore branch builds, but only for 'main'. We obviously need the action to run on 'main' so we can deploy the snapshot and generally ensure it's green.