### PR TITLE
Change time argument input types to `LocalTime` or `ZonedDateTime`

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceMerger.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceMerger.kt
@@ -26,6 +26,7 @@ import app.cash.paraphrase.plugin.TokenType.Select
 import app.cash.paraphrase.plugin.TokenType.SelectOrdinal
 import app.cash.paraphrase.plugin.TokenType.SpellOut
 import app.cash.paraphrase.plugin.TokenType.Time
+import app.cash.paraphrase.plugin.TokenType.TimeWithZone
 import app.cash.paraphrase.plugin.model.MergedResource
 import app.cash.paraphrase.plugin.model.PublicResource
 import app.cash.paraphrase.plugin.model.ResourceFolder
@@ -33,8 +34,9 @@ import app.cash.paraphrase.plugin.model.ResourceName
 import app.cash.paraphrase.plugin.model.TokenizedResource
 import app.cash.paraphrase.plugin.model.TokenizedResource.Token.NamedToken
 import app.cash.paraphrase.plugin.model.TokenizedResource.Token.NumberedToken
-import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZonedDateTime
 import kotlin.Number as KotlinNumber
 import kotlin.time.Duration as KotlinDuration
 
@@ -76,7 +78,8 @@ internal fun mergeResources(
       None -> Any::class
       Number, SpellOut -> KotlinNumber::class
       Date -> LocalDate::class
-      Time -> Instant::class
+      Time -> LocalTime::class
+      TimeWithZone -> ZonedDateTime::class
       Duration -> KotlinDuration::class
       Choice, Ordinal, Plural, SelectOrdinal -> Int::class
       Select -> String::class

--- a/sample/app/src/main/java/app/cash/paraphrase/sample/app/MainActivity.kt
+++ b/sample/app/src/main/java/app/cash/paraphrase/sample/app/MainActivity.kt
@@ -33,8 +33,9 @@ import app.cash.paraphrase.FormattedResource
 import app.cash.paraphrase.getString
 import app.cash.paraphrase.sample.app.FormattedResources as AppFormattedResources
 import app.cash.paraphrase.sample.library.FormattedResources as LibraryFormattedResources
-import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZonedDateTime
 
 class MainActivity : ComponentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
@@ -97,7 +98,7 @@ class MainActivity : ComponentActivity() {
       ),
       Sample(
         label = "Time Argument",
-        resource = AppFormattedResources.app_time_argument(showtime = Instant.now()),
+        resource = AppFormattedResources.app_time_argument(showtime = ZonedDateTime.now()),
       ),
       Sample(
         label = "Plural Argument",
@@ -128,7 +129,7 @@ class MainActivity : ComponentActivity() {
       ),
       Sample(
         label = "Time Argument",
-        resource = LibraryFormattedResources.library_time_argument(showtime = Instant.now()),
+        resource = LibraryFormattedResources.library_time_argument(showtime = LocalTime.now()),
       ),
       Sample(
         label = "Plural Argument",

--- a/sample/app/src/main/res/values/strings.xml
+++ b/sample/app/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
   <string name="app_text_argument">{name}</string>
   <string name="app_date_argument">{release_date, date, full}</string>
   <string name="app_number_argument">{budget, number}</string>
-  <string name="app_time_argument">{showtime, time, short}</string>
+  <string name="app_time_argument">{showtime, time, long}</string>
   <string name="app_plural_argument">
     {count, plural,
       =0 {Jobu does not order any bagels}

--- a/tests/src/main/kotlin/app/cash/paraphrase/tests/TypesTest.kt
+++ b/tests/src/main/kotlin/app/cash/paraphrase/tests/TypesTest.kt
@@ -18,10 +18,12 @@ package app.cash.paraphrase.tests
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.paraphrase.getString
 import com.google.common.truth.Truth.assertThat
-import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.Month
 import java.time.ZoneId
+import java.time.ZonedDateTime
 import java.util.Locale
-import java.util.TimeZone
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
@@ -31,12 +33,16 @@ import org.junit.Test
 class TypesTest {
   @get:Rule val localeRule = LocaleAndTimeZoneRule(
     locale = Locale("en", "US"),
-    timeZone = TimeZone.getTimeZone("Pacific/Honolulu"),
   )
 
   private val context = InstrumentationRegistry.getInstrumentation().context
-  private val releaseInstant = Instant.ofEpochSecond(1648185825)
-  private val releaseDate = releaseInstant.atZone(ZoneId.of("Pacific/Honolulu")).toLocalDate()
+  private val releaseDate = LocalDate.of(2022, Month.MARCH, 24)
+  private val releaseTime = LocalTime.of(19, 23, 45)
+  private val releaseDateTime = ZonedDateTime.of(
+    releaseDate,
+    releaseTime,
+    ZoneId.of("Pacific/Honolulu"),
+  )
 
   @Test fun typeNone() {
     val formattedString = context.getString(FormattedResources.type_none("Z"))
@@ -45,7 +51,8 @@ class TypesTest {
     assertThat(formattedInteger).isEqualTo("A 2 B")
     val formattedDouble = context.getString(FormattedResources.type_none(2.345))
     assertThat(formattedDouble).isEqualTo("A 2.345 B")
-    val formattedInstant = context.getString(FormattedResources.type_none(releaseInstant))
+    val formattedInstant =
+      context.getString(FormattedResources.type_none(releaseDateTime.toInstant()))
     assertThat(formattedInstant).isEqualTo("A 2022-03-25T05:23:45Z B")
   }
 
@@ -107,33 +114,53 @@ class TypesTest {
   }
 
   @Test fun typeTime() {
-    val formatted = context.getString(FormattedResources.type_time(releaseInstant))
+    val formatted = context.getString(FormattedResources.type_time(releaseTime))
     assertThat(formatted).isEqualTo("A 7:23:45 PM B")
   }
 
   @Test fun typeTimeShort() {
-    val formatted = context.getString(FormattedResources.type_time_short(releaseInstant))
+    val formatted = context.getString(FormattedResources.type_time_short(releaseTime))
     assertThat(formatted).isEqualTo("A 7:23 PM B")
   }
 
   @Test fun typeTimeMedium() {
-    val formatted = context.getString(FormattedResources.type_time_medium(releaseInstant))
+    val formatted = context.getString(FormattedResources.type_time_medium(releaseTime))
     assertThat(formatted).isEqualTo("A 7:23:45 PM B")
   }
 
   @Test fun typeTimeLong() {
-    val formatted = context.getString(FormattedResources.type_time_long(releaseInstant))
+    val formatted = context.getString(FormattedResources.type_time_long(releaseDateTime))
     assertThat(formatted).isEqualTo("A 7:23:45 PM HST B")
   }
 
   @Test fun typeTimeFull() {
-    val formatted = context.getString(FormattedResources.type_time_full(releaseInstant))
+    val formatted = context.getString(FormattedResources.type_time_full(releaseDateTime))
     assertThat(formatted).isEqualTo("A 7:23:45 PM Hawaii-Aleutian Standard Time B")
   }
 
   @Test fun typeTimeCustom() {
-    val formatted = context.getString(FormattedResources.type_time_custom(releaseInstant))
+    val formatted = context.getString(FormattedResources.type_time_custom(releaseDateTime))
     assertThat(formatted).isEqualTo("A 19-23-45 B")
+  }
+
+  @Test fun typeTimeWithWinterTimeZone() {
+    val winterDateTime = ZonedDateTime.of(
+      LocalDate.of(2023, Month.FEBRUARY, 17),
+      LocalTime.NOON,
+      ZoneId.of("America/Chicago"),
+    )
+    val formatted = context.getString(FormattedResources.type_time_long(winterDateTime))
+    assertThat(formatted).isEqualTo("A 12:00:00 PM CST B")
+  }
+
+  @Test fun typeTimeWithSummerTimeZone() {
+    val summerDateTime = ZonedDateTime.of(
+      LocalDate.of(2023, Month.JULY, 17),
+      LocalTime.NOON,
+      ZoneId.of("America/Chicago"),
+    )
+    val formatted = context.getString(FormattedResources.type_time_long(summerDateTime))
+    assertThat(formatted).isEqualTo("A 12:00:00 PM CDT B")
   }
 
   @Test fun typeDuration() {


### PR DESCRIPTION
Closes #57. I'll file a new issue for determining param type for skeletons & patterns.

This updates the generated formatting functions for times to take `LocalTime` or `ZonedDateTime`, depending on the length. `short` and `medium` times are formatted without a time zone. `long` and `full` times are formatted with a time zone.

(Note that `long`'s inclusion of a time zone differs from the examples [here](https://unicode-org.github.io/icu/userguide/format_parse/datetime/#producing-normal-date-formats-for-a-locale). Not sure whether there is a typo in those examples or Android explicitly changed this behavior.)

When a time zone is included, the date must also be included, because the date can affect the name of the time zone. For example, the time zone in Chicago is "Central Standard Time" in the winter, but "Central Daylight Time" in the summer.