### PR TITLE
Parse all different date/time semantic types in ResourceTokenizer

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceMerger.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceMerger.kt
@@ -18,8 +18,12 @@ package app.cash.paraphrase.plugin
 import app.cash.paraphrase.plugin.TokenType.Choice
 import app.cash.paraphrase.plugin.TokenType.Date
 import app.cash.paraphrase.plugin.TokenType.DateTime
-import app.cash.paraphrase.plugin.TokenType.DateTimeWithZone
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithZoneId
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithZoneOffset
+import app.cash.paraphrase.plugin.TokenType.DateWithZoneId
+import app.cash.paraphrase.plugin.TokenType.DateWithZoneOffset
 import app.cash.paraphrase.plugin.TokenType.Duration
+import app.cash.paraphrase.plugin.TokenType.NoArg
 import app.cash.paraphrase.plugin.TokenType.None
 import app.cash.paraphrase.plugin.TokenType.Number
 import app.cash.paraphrase.plugin.TokenType.Ordinal
@@ -28,6 +32,8 @@ import app.cash.paraphrase.plugin.TokenType.Select
 import app.cash.paraphrase.plugin.TokenType.SelectOrdinal
 import app.cash.paraphrase.plugin.TokenType.SpellOut
 import app.cash.paraphrase.plugin.TokenType.Time
+import app.cash.paraphrase.plugin.TokenType.TimeWithZoneOffset
+import app.cash.paraphrase.plugin.TokenType.ZoneOffset
 import app.cash.paraphrase.plugin.model.MergedResource
 import app.cash.paraphrase.plugin.model.PublicResource
 import app.cash.paraphrase.plugin.model.ResourceFolder
@@ -82,7 +88,8 @@ internal fun mergeResources(
       Date -> LocalDate::class
       Time -> LocalTime::class
       DateTime -> LocalDateTime::class
-      DateTimeWithZone -> ZonedDateTime::class
+      // TODO: Map these to correct types
+      DateWithZoneOffset, DateWithZoneId, TimeWithZoneOffset, DateTimeWithZoneOffset, DateTimeWithZoneId, ZoneOffset, NoArg -> ZonedDateTime::class
       Duration -> KotlinDuration::class
       Choice, Ordinal, Plural, SelectOrdinal -> Int::class
       Select -> String::class

--- a/plugin/src/test/java/app/cash/paraphrase/plugin/ResourceTokenizerTest.kt
+++ b/plugin/src/test/java/app/cash/paraphrase/plugin/ResourceTokenizerTest.kt
@@ -16,12 +16,20 @@
 package app.cash.paraphrase.plugin
 
 import app.cash.paraphrase.plugin.TokenType.Date
+import app.cash.paraphrase.plugin.TokenType.DateTime
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithZoneId
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithZoneOffset
+import app.cash.paraphrase.plugin.TokenType.DateWithZoneId
+import app.cash.paraphrase.plugin.TokenType.DateWithZoneOffset
+import app.cash.paraphrase.plugin.TokenType.NoArg
 import app.cash.paraphrase.plugin.TokenType.None
 import app.cash.paraphrase.plugin.TokenType.Number
 import app.cash.paraphrase.plugin.TokenType.Plural
 import app.cash.paraphrase.plugin.TokenType.Select
 import app.cash.paraphrase.plugin.TokenType.SelectOrdinal
 import app.cash.paraphrase.plugin.TokenType.Time
+import app.cash.paraphrase.plugin.TokenType.TimeWithZoneOffset
+import app.cash.paraphrase.plugin.TokenType.ZoneOffset
 import app.cash.paraphrase.plugin.model.ResourceName
 import app.cash.paraphrase.plugin.model.StringResource
 import app.cash.paraphrase.plugin.model.TokenizedResource
@@ -195,6 +203,75 @@ class ResourceTokenizerTest {
         NumberedToken(number = 0, type = None),
         NumberedToken(number = 0, type = None),
       )
+  }
+
+  @Test
+  fun tokenizeResourceWithDateFormat() {
+    """
+      Test
+      {short, date, short}
+      {medium, date, medium}
+      {long, date, long}
+      {full, date, full}
+    """.trimIndent()
+      .assertTokens(
+        NamedToken(name = "short", type = Date),
+        NamedToken(name = "medium", type = Date),
+        NamedToken(name = "long", type = Date),
+        NamedToken(name = "full", type = Date),
+      )
+  }
+
+  @Test
+  fun tokenizeResourceWithTimeFormat() {
+    """
+      Test
+      {short, time, short}
+      {medium, time, medium}
+      {long, time, long}
+      {full, time, full}
+    """.trimIndent()
+      .assertTokens(
+        NamedToken(name = "short", type = Time),
+        NamedToken(name = "medium", type = Time),
+        NamedToken(name = "long", type = DateTimeWithZoneId),
+        NamedToken(name = "full", type = DateTimeWithZoneId),
+      )
+  }
+
+  @Test
+  fun tokenizeResourceWithDateTimeFormatPattern() {
+    for (type in setOf("date", "time")) {
+      """
+        Test
+        {date_time_id, $type, yaz}
+        {date_time_offset, $type, MbZ}
+        {date_time, $type, Lh}
+        {date_id, $type, wz}
+        {date_offset, $type, WO}
+        {date, $type, d}
+        {time_id, $type, Hv}
+        {time_offset, $type, mX}
+        {time, $type, s}
+        {id, $type, V}
+        {offset, $type, x}
+        {no_arg, $type, 'yaz'}
+      """.trimIndent()
+        .assertTokens(
+          NamedToken(name = "date_time_id", type = DateTimeWithZoneId),
+          NamedToken(name = "date_time_offset", type = DateTimeWithZoneOffset),
+          NamedToken(name = "date_time", type = DateTime),
+          NamedToken(name = "date_id", type = DateWithZoneId),
+          NamedToken(name = "date_offset", type = DateWithZoneOffset),
+          NamedToken(name = "date", type = Date),
+          NamedToken(name = "time_id", type = DateTimeWithZoneId),
+          NamedToken(name = "time_offset", type = TimeWithZoneOffset),
+          NamedToken(name = "time", type = Time),
+          NamedToken(name = "id", type = DateWithZoneId),
+          NamedToken(name = "offset", type = ZoneOffset),
+          NamedToken(name = "no_arg", type = NoArg),
+        )
+    }
   }
 
   @Test


### PR DESCRIPTION
This lays the groundwork for implementing the 3 improvements mentioned in #93. This does not change any behavior yet, so all the new date/time types still yield a `ZonedDateTime` arg. Several of them can be easily switched to a better type and some will take a bit more work.

I'm pretty sure I've mapped [time zone symbols](https://unicode-org.github.io/icu/userguide/format_parse/datetime/#date-field-symbol-table) to `ZoneId` or `ZoneOffset` correctly, but a sanity check would be appreciated.