### PR TITLE
Replace jvmToolchain requirements with jvmTarget settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,7 @@
+import com.android.build.gradle.LibraryExtension
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.diffplug.gradle.spotless.SpotlessExtension
-import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 buildscript {
   dependencies {
@@ -56,9 +58,26 @@ subprojects {
     }
   }
 
-  plugins.withId("org.jetbrains.kotlin.android") {
-    extensions.getByType<KotlinTopLevelExtension>().jvmToolchain {
-      languageVersion.set(JavaLanguageVersion.of(8))
+  val javaVersion = JavaVersion.VERSION_1_8.toString()
+  tasks.withType<KotlinJvmCompile> {
+    kotlinOptions {
+      jvmTarget = javaVersion
+    }
+  }
+  plugins.withId("com.android.library") {
+    with(extensions.getByType<LibraryExtension>()) {
+      compileOptions {
+        sourceCompatibility(javaVersion)
+        targetCompatibility(javaVersion)
+      }
+    }
+  }
+  plugins.withId("com.android.application") {
+    with(extensions.getByType<BaseAppModuleExtension>()) {
+      compileOptions {
+        sourceCompatibility(javaVersion)
+        targetCompatibility(javaVersion)
+      }
     }
   }
 }

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
+
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
   `java-gradle-plugin`
@@ -23,9 +25,9 @@ gradlePlugin {
   }
 }
 
-kotlin {
-  jvmToolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
+tasks.withType<KotlinJvmCompile> {
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_11.toString()
   }
 }
 


### PR DESCRIPTION
See [this discussion](https://github.com/cashapp/paraphrase/pull/96#discussion_r1119431314). This should ensure that the project is built with the machine default JDK (CI currently uses JDK 19) rather than JDK 8. Code still targets JVM 8, except for `:plugin` which targets JVM 11.