### PR TITLE
Support OffsetTime, OffsetDateTime, and ZoneOffset

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceMerger.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceMerger.kt
@@ -18,22 +18,20 @@ package app.cash.paraphrase.plugin
 import app.cash.paraphrase.plugin.TokenType.Choice
 import app.cash.paraphrase.plugin.TokenType.Date
 import app.cash.paraphrase.plugin.TokenType.DateTime
-import app.cash.paraphrase.plugin.TokenType.DateTimeWithZoneId
-import app.cash.paraphrase.plugin.TokenType.DateTimeWithZoneOffset
-import app.cash.paraphrase.plugin.TokenType.DateWithZoneId
-import app.cash.paraphrase.plugin.TokenType.DateWithZoneOffset
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithOffset
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithZone
 import app.cash.paraphrase.plugin.TokenType.Duration
 import app.cash.paraphrase.plugin.TokenType.NoArg
 import app.cash.paraphrase.plugin.TokenType.None
 import app.cash.paraphrase.plugin.TokenType.Number
+import app.cash.paraphrase.plugin.TokenType.Offset
 import app.cash.paraphrase.plugin.TokenType.Ordinal
 import app.cash.paraphrase.plugin.TokenType.Plural
 import app.cash.paraphrase.plugin.TokenType.Select
 import app.cash.paraphrase.plugin.TokenType.SelectOrdinal
 import app.cash.paraphrase.plugin.TokenType.SpellOut
 import app.cash.paraphrase.plugin.TokenType.Time
-import app.cash.paraphrase.plugin.TokenType.TimeWithZoneOffset
-import app.cash.paraphrase.plugin.TokenType.ZoneOffset
+import app.cash.paraphrase.plugin.TokenType.TimeWithOffset
 import app.cash.paraphrase.plugin.model.MergedResource
 import app.cash.paraphrase.plugin.model.PublicResource
 import app.cash.paraphrase.plugin.model.ResourceFolder
@@ -44,6 +42,9 @@ import app.cash.paraphrase.plugin.model.TokenizedResource.Token.NumberedToken
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import kotlin.Number as KotlinNumber
 import kotlin.time.Duration as KotlinDuration
@@ -87,9 +88,12 @@ internal fun mergeResources(
       Number, SpellOut -> KotlinNumber::class
       Date -> LocalDate::class
       Time -> LocalTime::class
+      TimeWithOffset -> OffsetTime::class
       DateTime -> LocalDateTime::class
-      // TODO: Map these to correct types
-      DateWithZoneOffset, DateWithZoneId, TimeWithZoneOffset, DateTimeWithZoneOffset, DateTimeWithZoneId, ZoneOffset, NoArg -> ZonedDateTime::class
+      DateTimeWithOffset -> OffsetDateTime::class
+      // TODO: Handle NoArg?
+      DateTimeWithZone, NoArg -> ZonedDateTime::class
+      Offset -> ZoneOffset::class
       Duration -> KotlinDuration::class
       Choice, Ordinal, Plural, SelectOrdinal -> Int::class
       Select -> String::class

--- a/plugin/src/test/java/app/cash/paraphrase/plugin/ResourceTokenizerTest.kt
+++ b/plugin/src/test/java/app/cash/paraphrase/plugin/ResourceTokenizerTest.kt
@@ -17,19 +17,17 @@ package app.cash.paraphrase.plugin
 
 import app.cash.paraphrase.plugin.TokenType.Date
 import app.cash.paraphrase.plugin.TokenType.DateTime
-import app.cash.paraphrase.plugin.TokenType.DateTimeWithZoneId
-import app.cash.paraphrase.plugin.TokenType.DateTimeWithZoneOffset
-import app.cash.paraphrase.plugin.TokenType.DateWithZoneId
-import app.cash.paraphrase.plugin.TokenType.DateWithZoneOffset
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithOffset
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithZone
 import app.cash.paraphrase.plugin.TokenType.NoArg
 import app.cash.paraphrase.plugin.TokenType.None
 import app.cash.paraphrase.plugin.TokenType.Number
+import app.cash.paraphrase.plugin.TokenType.Offset
 import app.cash.paraphrase.plugin.TokenType.Plural
 import app.cash.paraphrase.plugin.TokenType.Select
 import app.cash.paraphrase.plugin.TokenType.SelectOrdinal
 import app.cash.paraphrase.plugin.TokenType.Time
-import app.cash.paraphrase.plugin.TokenType.TimeWithZoneOffset
-import app.cash.paraphrase.plugin.TokenType.ZoneOffset
+import app.cash.paraphrase.plugin.TokenType.TimeWithOffset
 import app.cash.paraphrase.plugin.model.ResourceName
 import app.cash.paraphrase.plugin.model.StringResource
 import app.cash.paraphrase.plugin.model.TokenizedResource
@@ -234,8 +232,8 @@ class ResourceTokenizerTest {
       .assertTokens(
         NamedToken(name = "short", type = Time),
         NamedToken(name = "medium", type = Time),
-        NamedToken(name = "long", type = DateTimeWithZoneId),
-        NamedToken(name = "full", type = DateTimeWithZoneId),
+        NamedToken(name = "long", type = DateTimeWithZone),
+        NamedToken(name = "full", type = DateTimeWithZone),
       )
   }
 
@@ -258,17 +256,17 @@ class ResourceTokenizerTest {
         {no_arg, $type, 'yaz'}
       """.trimIndent()
         .assertTokens(
-          NamedToken(name = "date_time_id", type = DateTimeWithZoneId),
-          NamedToken(name = "date_time_offset", type = DateTimeWithZoneOffset),
+          NamedToken(name = "date_time_id", type = DateTimeWithZone),
+          NamedToken(name = "date_time_offset", type = DateTimeWithOffset),
           NamedToken(name = "date_time", type = DateTime),
-          NamedToken(name = "date_id", type = DateWithZoneId),
-          NamedToken(name = "date_offset", type = DateWithZoneOffset),
+          NamedToken(name = "date_id", type = DateTimeWithZone),
+          NamedToken(name = "date_offset", type = DateTimeWithOffset),
           NamedToken(name = "date", type = Date),
-          NamedToken(name = "time_id", type = DateTimeWithZoneId),
-          NamedToken(name = "time_offset", type = TimeWithZoneOffset),
+          NamedToken(name = "time_id", type = DateTimeWithZone),
+          NamedToken(name = "time_offset", type = TimeWithOffset),
           NamedToken(name = "time", type = Time),
-          NamedToken(name = "id", type = DateWithZoneId),
-          NamedToken(name = "offset", type = ZoneOffset),
+          NamedToken(name = "id", type = DateTimeWithZone),
+          NamedToken(name = "offset", type = Offset),
           NamedToken(name = "no_arg", type = NoArg),
         )
     }

--- a/tests/src/main/kotlin/app/cash/paraphrase/tests/TypesTest.kt
+++ b/tests/src/main/kotlin/app/cash/paraphrase/tests/TypesTest.kt
@@ -21,7 +21,9 @@ import com.google.common.truth.Truth.assertThat
 import java.time.LocalDate
 import java.time.LocalTime
 import java.time.Month
+import java.time.OffsetTime
 import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.ZonedDateTime
 import java.util.Locale
 import kotlin.time.Duration.Companion.hours
@@ -114,6 +116,13 @@ class TypesTest {
     assertThat(formatted).isEqualTo("A 3-24, 7PM HST B")
   }
 
+  @Test fun typeDatePatternDateTimeOffset() {
+    val formatted = context.getString(
+      FormattedResources.type_date_pattern_date_time_offset(releaseDateTime.toOffsetDateTime()),
+    )
+    assertThat(formatted).isEqualTo("A 3-24, 7PM -10:00 B")
+  }
+
   @Test fun typeDatePatternDateTime() {
     val localDateTime = releaseDateTime.toLocalDateTime()
     val formatted = context.getString(FormattedResources.type_date_pattern_date_time(localDateTime))
@@ -124,6 +133,13 @@ class TypesTest {
     val formatted =
       context.getString(FormattedResources.type_date_pattern_date_zone(releaseDateTime))
     assertThat(formatted).isEqualTo("A March (HST) B")
+  }
+
+  @Test fun typeDatePatternDateOffset() {
+    val formatted = context.getString(
+      FormattedResources.type_date_pattern_date_offset(releaseDateTime.toOffsetDateTime()),
+    )
+    assertThat(formatted).isEqualTo("A March (-10:00) B")
   }
 
   @Test fun typeDatePatternDate() {
@@ -137,6 +153,16 @@ class TypesTest {
     assertThat(formatted).isEqualTo("A 19:23 HST B")
   }
 
+  @Test fun typeDatePatternTimeOffset() {
+    val formatted = context.getString(
+      FormattedResources.type_date_pattern_time_offset(
+        // Ensures the UTC/GMT case works:
+        releaseDateTime.withZoneSameLocal(ZoneOffset.UTC).toOffsetDateTime().toOffsetTime(),
+      ),
+    )
+    assertThat(formatted).isEqualTo("A 19:23+0000 B")
+  }
+
   @Test fun typeDatePatternTime() {
     val formatted = context.getString(FormattedResources.type_date_pattern_time(releaseTime))
     assertThat(formatted).isEqualTo("A 23 past 7 B")
@@ -145,6 +171,13 @@ class TypesTest {
   @Test fun typeDatePatternZone() {
     val formatted = context.getString(FormattedResources.type_date_pattern_zone(releaseDateTime))
     assertThat(formatted).isEqualTo("A Hawaii-Aleutian Standard Time B")
+  }
+
+  @Test fun typeDatePatternOffset() {
+    val formatted = context.getString(
+      FormattedResources.type_date_pattern_offset(releaseDateTime.offset),
+    )
+    assertThat(formatted).isEqualTo("A GMT-10:00 B")
   }
 
   @Test fun typeDatePatternNone() {
@@ -183,6 +216,13 @@ class TypesTest {
     assertThat(formatted).isEqualTo("A 3-24, 7PM HST B")
   }
 
+  @Test fun typeTimePatternDateTimeOffset() {
+    val formatted = context.getString(
+      FormattedResources.type_time_pattern_date_time_offset(releaseDateTime.toOffsetDateTime()),
+    )
+    assertThat(formatted).isEqualTo("A 3-24, 7PM -10 B")
+  }
+
   @Test fun typeTimePatternDateTime() {
     val localDateTime = releaseDateTime.toLocalDateTime()
     val formatted = context.getString(FormattedResources.type_time_pattern_date_time(localDateTime))
@@ -193,6 +233,13 @@ class TypesTest {
     val formatted =
       context.getString(FormattedResources.type_time_pattern_date_zone(releaseDateTime))
     assertThat(formatted).isEqualTo("A March (HST) B")
+  }
+
+  @Test fun typeTimePatternDateOffset() {
+    val formatted = context.getString(
+      FormattedResources.type_time_pattern_date_offset(releaseDateTime.toOffsetDateTime()),
+    )
+    assertThat(formatted).isEqualTo("A March (-10) B")
   }
 
   @Test fun typeTimePatternDate() {
@@ -206,6 +253,15 @@ class TypesTest {
     assertThat(formatted).isEqualTo("A 19:23 HST B")
   }
 
+  @Test fun typeTimePatternTimeOffset() {
+    val formatted = context.getString(
+      FormattedResources.type_time_pattern_time_offset(
+        OffsetTime.of(releaseDateTime.toLocalTime(), releaseDateTime.offset),
+      ),
+    )
+    assertThat(formatted).isEqualTo("A 19:23-1000 B")
+  }
+
   @Test fun typeTimePatternTime() {
     val formatted = context.getString(FormattedResources.type_time_pattern_time(releaseTime))
     assertThat(formatted).isEqualTo("A 19-23-45 B")
@@ -214,6 +270,13 @@ class TypesTest {
   @Test fun typeTimePatternZone() {
     val formatted = context.getString(FormattedResources.type_time_pattern_zone(releaseDateTime))
     assertThat(formatted).isEqualTo("A Hawaii-Aleutian Standard Time B")
+  }
+
+  @Test fun typeTimePatternOffset() {
+    val formatted = context.getString(
+      FormattedResources.type_time_pattern_offset(releaseDateTime.offset),
+    )
+    assertThat(formatted).isEqualTo("A GMT-10:00 B")
   }
 
   @Test fun typeTimePatternNone() {

--- a/tests/src/main/res/values/types.xml
+++ b/tests/src/main/res/values/types.xml
@@ -13,12 +13,16 @@
   <string name="type_date_long">A {value,date,long} B</string>
   <string name="type_date_full">A {value,date,full} B</string>
   <string name="type_date_pattern_date_time_zone">A {value,date,M-dd, ha z} B</string>
+  <string name="type_date_pattern_date_time_offset">A {value,date,M-dd, ha xxx} B</string>
   <string name="type_date_pattern_date_time">A {value,date,M-dd ha} B</string>
   <string name="type_date_pattern_date_zone">A {value,date,MMMM (z)} B</string>
+  <string name="type_date_pattern_date_offset">A {value,date,MMMM (xxx)} B</string>
   <string name="type_date_pattern_date">A {value,date,YYYY-MM-dd} B</string>
   <string name="type_date_pattern_time_zone">A {value,date,HH:mm zz} B</string>
+  <string name="type_date_pattern_time_offset">A {value,date,HH:mmZ} B</string>
   <string name="type_date_pattern_time">A {value,date,m \'past\' h} B</string>
   <string name="type_date_pattern_zone">A {value,date,zzzz} B</string>
+  <string name="type_date_pattern_offset">A {value,date,ZZZZ} B</string>
   <string name="type_date_pattern_none">A {value,date,\'What is this for?\'} B</string>
 
   <string name="type_time">A {value,time} B</string>
@@ -27,12 +31,16 @@
   <string name="type_time_long">A {value,time,long} B</string>
   <string name="type_time_full">A {value,time,full} B</string>
   <string name="type_time_pattern_date_time_zone">A {value,time,M-dd, ha z} B</string>
+  <string name="type_time_pattern_date_time_offset">A {value,time,M-dd, ha x} B</string>
   <string name="type_time_pattern_date_time">A {value,time,M-dd ha} B</string>
   <string name="type_time_pattern_date_zone">A {value,time,MMMM (z)} B</string>
+  <string name="type_time_pattern_date_offset">A {value,time,MMMM (x)} B</string>
   <string name="type_time_pattern_date">A {value,time,YYYY-MM-dd} B</string>
   <string name="type_time_pattern_time_zone">A {value,time,HH:mm zz} B</string>
+  <string name="type_time_pattern_time_offset">A {value,time,HH:mmZ} B</string>
   <string name="type_time_pattern_time">A {value,time,HH-mm-ss} B</string>
   <string name="type_time_pattern_zone">A {value,time,zzzz} B</string>
+  <string name="type_time_pattern_offset">A {value,time,ZZZZ} B</string>
   <string name="type_time_pattern_none">A {value,time,\'What is this for?\'} B</string>
 
   <string name="type_duration">A {value,duration} B</string>


### PR DESCRIPTION
Uses these arg types when the date/time format only needs a zone offset rather than a (region-based) zone ID. Finishes most of #92.

In `ResourceWriter`, some of the KotlinPoet `Calendar` creation logic is pulled into reused functions because it was duplicated a lot and somewhat complex.

In many places, things named `*ZoneId` have been renamed to `*Zone`, and things names `*ZoneOffset` have been renamed to `*Offset`. This was initially to avoid a conflict between `TokenType.ZoneOffset` and `java.time.ZoneOffset`, but it also makes everything a bit easier to read.

In `ResourceTokenizer`:
* `DateWithZone` token type has been merged back into `DateTimeWithZone`. It occurred to me that formatting a `ZoneId` requires the time, because some `ZoneId`s change formatted name at a time other than midnight (e.g. all the US time zones).
* `DateWithOffset` token type has been merged back into `DateTimeWithOffset`. `java.time.OffsetDate` doesn't exist and I think doing a `Pair<LocalDate, ZoneOffset>` would be janky, so let's just require the time even though it's not needed. I imagine this is a rare format anyway.