### PR TITLE
Support `Nothing?` arg for fully escaped date/time formats

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceMerger.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceMerger.kt
@@ -91,12 +91,12 @@ internal fun mergeResources(
       TimeWithOffset -> OffsetTime::class
       DateTime -> LocalDateTime::class
       DateTimeWithOffset -> OffsetDateTime::class
-      // TODO: Handle NoArg?
-      DateTimeWithZone, NoArg -> ZonedDateTime::class
+      DateTimeWithZone -> ZonedDateTime::class
       Offset -> ZoneOffset::class
       Duration -> KotlinDuration::class
       Choice, Ordinal, Plural, SelectOrdinal -> Int::class
       Select -> String::class
+      NoArg -> Nothing::class
     }
     MergedResource.Argument(
       key = argumentKey,

--- a/tests/src/main/kotlin/app/cash/paraphrase/tests/TypesTest.kt
+++ b/tests/src/main/kotlin/app/cash/paraphrase/tests/TypesTest.kt
@@ -181,7 +181,7 @@ class TypesTest {
   }
 
   @Test fun typeDatePatternNone() {
-    val formatted = context.getString(FormattedResources.type_date_pattern_none(releaseDateTime))
+    val formatted = context.getString(FormattedResources.type_date_pattern_none(null))
     assertThat(formatted).isEqualTo("A What is this for? B")
   }
 
@@ -280,7 +280,7 @@ class TypesTest {
   }
 
   @Test fun typeTimePatternNone() {
-    val formatted = context.getString(FormattedResources.type_time_pattern_none(releaseDateTime))
+    val formatted = context.getString(FormattedResources.type_time_pattern_none(null))
     assertThat(formatted).isEqualTo("A What is this for? B")
   }
 


### PR DESCRIPTION
Since date/time formats support escaping text with `'`, it is possible to create a format that is just a static string:
```
{name, time, 'Nothing to see here.'}
```

That means, from a type-safe arg perspective, no type is required. This PR exposes this as a `Nothing?` arg, so the consumer must pass `null`. I've chosen this because it holds the pattern of "1 ICU format substring == 1 Kotlin arg", and the strange type highlights to the consumer that they're doing something they probably don't want to be doing. (If this is a bad idea it's probably not too tricky to make it actually produce no Kotlin args for this case.)

Oddly, ICU still requires an arg in this case: if we pass `null` or no argument to the formatter, ICU [replaces the whole format string with the string "null"](https://cs.android.com/android/platform/superproject/+/master:external/icu/android_icu4j/src/main/java/android/icu/text/MessageFormat.java;l=1626-1627). I don't know why it does this. This PR handles this case internally by passing `-1` as the argument, which gets ignored but allows the escaped format text to make it through to the final formatted text.

Closes #92.