### PR TITLE
Group Kotlin and Compose compiler for Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      // Compose compiler is tightly coupled to Kotlin version
+      "groupName": "Kotlin and Compose",
+      "matchPackagePrefixes": [
+        "androidx.compose.compiler",
+        "org.jetbrains.kotlin",
+      ],
+    },
+  ],
+}


### PR DESCRIPTION
because Compose compiler is tightly coupled to Kotlin version.

I'm new to Renovate; is there a good way to test whether I've done this right before merging? Goal is to combine #81 and #113 into a single PR.

Also updated Renovate config to `.json5` so I could add a comment.