### PR TITLE
Add Compose compiler to libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 agp = "7.4.2"
+compose-compiler = "1.4.0"
 kotlin = "1.8.0"
 ktlint = "0.48.1"
 
@@ -8,6 +9,7 @@ agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 androidActivityCompose = "androidx.activity:activity-compose:1.6.1"
 androidAnnotation = "androidx.annotation:annotation:1.6.0"
 androidTestRunner = "androidx.test:runner:1.5.2"
+composeCompiler = { module = "androidx.compose.compiler:compiler", version.ref = "compose-compiler" }
 composeMaterial = "androidx.compose.material:material:1.3.1"
 composeUi = "androidx.compose.ui:ui:1.3.3"
 googleMaterial = "com.google.android.material:material:1.8.0"

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -14,7 +14,7 @@ android {
   }
 
   composeOptions {
-    kotlinCompilerExtensionVersion = "1.4.0"
+    kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
   }
 
   defaultConfig {


### PR DESCRIPTION
#116 didn't have the Compose update in it. renovatebot/renovate#18354 suggests this is because `kotlinCompilerExtensionVersion` is a special case, and one comment suggests adding it (and its full package reference, though not directly used) to `libs.versions.toml`, so giving that a try.