### PR TITLE
Resolve type conflicts intelligently

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ArgumentTypeResolver.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ArgumentTypeResolver.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paraphrase.plugin
+
+import app.cash.paraphrase.plugin.TokenType.Choice
+import app.cash.paraphrase.plugin.TokenType.Date
+import app.cash.paraphrase.plugin.TokenType.DateTime
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithOffset
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithZone
+import app.cash.paraphrase.plugin.TokenType.Duration
+import app.cash.paraphrase.plugin.TokenType.NoArg
+import app.cash.paraphrase.plugin.TokenType.None
+import app.cash.paraphrase.plugin.TokenType.Number
+import app.cash.paraphrase.plugin.TokenType.Offset
+import app.cash.paraphrase.plugin.TokenType.Ordinal
+import app.cash.paraphrase.plugin.TokenType.Plural
+import app.cash.paraphrase.plugin.TokenType.Select
+import app.cash.paraphrase.plugin.TokenType.SelectOrdinal
+import app.cash.paraphrase.plugin.TokenType.SpellOut
+import app.cash.paraphrase.plugin.TokenType.Time
+import app.cash.paraphrase.plugin.TokenType.TimeWithOffset
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import kotlin.Number as KotlinNumber
+import kotlin.reflect.KClass
+import kotlin.time.Duration as KotlinDuration
+
+/**
+ * Returns the final argument type for the given list of token types, or null if there is no
+ * suitable argument type for the given combination of token types.
+ *
+ * For example:
+ * - [Date] -> [LocalDate]
+ * - [Date] + [Time] -> [LocalDateTime]
+ * - [Date] + [Plural] -> null
+ */
+internal fun resolveArgumentType(tokenTypes: List<TokenType>): KClass<*>? =
+  when (resolveCompatibleTokenType(tokenTypes)) {
+    null -> null
+    None -> Any::class
+    Number, SpellOut -> KotlinNumber::class
+    Date -> LocalDate::class
+    Time -> LocalTime::class
+    TimeWithOffset -> OffsetTime::class
+    DateTime -> LocalDateTime::class
+    DateTimeWithOffset -> OffsetDateTime::class
+    DateTimeWithZone -> ZonedDateTime::class
+    Offset -> ZoneOffset::class
+    Duration -> KotlinDuration::class
+    Choice, Ordinal, Plural, SelectOrdinal -> Int::class
+    Select -> String::class
+    NoArg -> Nothing::class
+  }
+
+private fun resolveCompatibleTokenType(tokens: List<TokenType>): TokenType? =
+  tokens.reduceOrNull(::resolveCompatibleTokenType)
+
+private fun resolveCompatibleTokenType(first: TokenType?, second: TokenType?): TokenType? =
+  when {
+    first == null || second == null -> null
+    first == second || second.compatibleTypes.contains(first) -> first
+    first.compatibleTypes.contains(second) -> second
+    else -> first.compatibleTypes.firstOrNull { second.compatibleTypes.contains(it) }
+  }
+
+private val TokenType.compatibleTypes: List<TokenType>
+  get() = compatibleTokenTypes[this]!!
+
+/**
+ * For a token of type A, tokens of type B are considered compatible if the argument type that
+ * satisfies B also satisfies A.
+ *
+ * For example:
+ * - [DateTime] is compatible with [Date], because [LocalDateTime] contains the date information
+ *   required by [Date] tokens.
+ * - [Date] is not compatible with [DateTime], because [LocalDate] does not contain the time
+ *   information required by [DateTime] tokens.
+ *
+ * Compatible types are ordered from least restrictive to most restrictive. [ZonedDateTime] contains
+ * a superset of the information in [DateTime], so it comes later in the list of types compatible
+ * with [Date].
+ */
+private val compatibleTokenTypes: Map<TokenType, List<TokenType>> = mapOf(
+  None to TokenType.values().asList(),
+  Number to listOf(Choice, Ordinal, Plural, SelectOrdinal, SpellOut),
+  Date to listOf(DateTime, DateTimeWithOffset, DateTimeWithZone),
+  Time to listOf(DateTime, TimeWithOffset, DateTimeWithOffset, DateTimeWithZone),
+  TimeWithOffset to listOf(DateTimeWithOffset, DateTimeWithZone),
+  DateTime to listOf(DateTimeWithOffset, DateTimeWithZone),
+  DateTimeWithOffset to listOf(DateTimeWithZone),
+  DateTimeWithZone to emptyList(),
+  Offset to listOf(TimeWithOffset, DateTimeWithOffset, DateTimeWithZone),
+  SpellOut to listOf(Choice, Number, Ordinal, Plural, SelectOrdinal),
+  Ordinal to listOf(Choice, Plural, SelectOrdinal),
+  Duration to emptyList(),
+  Choice to listOf(Ordinal, Plural, SelectOrdinal),
+  Plural to listOf(Choice, Ordinal, SelectOrdinal),
+  Select to emptyList(),
+  SelectOrdinal to listOf(Choice, Ordinal, Plural),
+  NoArg to emptyList(),
+)

--- a/plugin/src/test/java/app/cash/paraphrase/plugin/ArgumentTypeResolverTest.kt
+++ b/plugin/src/test/java/app/cash/paraphrase/plugin/ArgumentTypeResolverTest.kt
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paraphrase.plugin
+
+import app.cash.paraphrase.plugin.TokenType.Choice
+import app.cash.paraphrase.plugin.TokenType.Date
+import app.cash.paraphrase.plugin.TokenType.DateTime
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithOffset
+import app.cash.paraphrase.plugin.TokenType.DateTimeWithZone
+import app.cash.paraphrase.plugin.TokenType.Duration
+import app.cash.paraphrase.plugin.TokenType.NoArg
+import app.cash.paraphrase.plugin.TokenType.None
+import app.cash.paraphrase.plugin.TokenType.Number
+import app.cash.paraphrase.plugin.TokenType.Offset
+import app.cash.paraphrase.plugin.TokenType.Ordinal
+import app.cash.paraphrase.plugin.TokenType.Plural
+import app.cash.paraphrase.plugin.TokenType.Select
+import app.cash.paraphrase.plugin.TokenType.SelectOrdinal
+import app.cash.paraphrase.plugin.TokenType.SpellOut
+import app.cash.paraphrase.plugin.TokenType.Time
+import app.cash.paraphrase.plugin.TokenType.TimeWithOffset
+import com.google.common.truth.Truth.assertThat
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.OffsetDateTime
+import java.time.OffsetTime
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+import kotlin.Number as KotlinNumber
+import kotlin.reflect.KClass
+import kotlin.time.Duration as KotlinDuration
+import org.junit.Test
+
+class ArgumentTypeResolverTest {
+  @Test
+  fun resolveEmpty() {
+    emptyList<TokenType>().assertArgumentType(null)
+  }
+
+  @Test
+  fun resolveNone() {
+    None.assertArgumentTypes { other ->
+      resolveArgumentType(listOf(other))
+    }
+  }
+
+  @Test
+  fun resolveNumber() {
+    Number.assertArgumentTypes { other ->
+      when (other) {
+        None, Number, SpellOut -> KotlinNumber::class
+        Choice, Ordinal, Plural, SelectOrdinal -> Int::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveDate() {
+    Date.assertArgumentTypes { other ->
+      when (other) {
+        None, Date -> LocalDate::class
+        Time, DateTime -> LocalDateTime::class
+        Offset, TimeWithOffset, DateTimeWithOffset -> OffsetDateTime::class
+        DateTimeWithZone -> ZonedDateTime::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveTime() {
+    Time.assertArgumentTypes { other ->
+      when (other) {
+        None, Time -> LocalTime::class
+        Date, DateTime -> LocalDateTime::class
+        Offset, TimeWithOffset -> OffsetTime::class
+        DateTimeWithOffset -> OffsetDateTime::class
+        DateTimeWithZone -> ZonedDateTime::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveOffset() {
+    Offset.assertArgumentTypes { other ->
+      when (other) {
+        None, Offset -> ZoneOffset::class
+        Date, DateTime, DateTimeWithOffset -> OffsetDateTime::class
+        Time, TimeWithOffset -> OffsetTime::class
+        DateTimeWithZone -> ZonedDateTime::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveDateTime() {
+    DateTime.assertArgumentTypes { other ->
+      when (other) {
+        None, Date, Time, DateTime -> LocalDateTime::class
+        Offset, TimeWithOffset, DateTimeWithOffset -> OffsetDateTime::class
+        DateTimeWithZone -> ZonedDateTime::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveTimeWithOffset() {
+    TimeWithOffset.assertArgumentTypes { other ->
+      when (other) {
+        None, Time, Offset, TimeWithOffset -> OffsetTime::class
+        Date, DateTime, DateTimeWithOffset -> OffsetDateTime::class
+        DateTimeWithZone -> ZonedDateTime::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveDateTimeWithOffset() {
+    DateTimeWithOffset.assertArgumentTypes { other ->
+      when (other) {
+        None, Date, Time, Offset, DateTime, TimeWithOffset, DateTimeWithOffset -> OffsetDateTime::class
+        DateTimeWithZone -> ZonedDateTime::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveDateTimeWithZone() {
+    DateTimeWithZone.assertArgumentTypes { other ->
+      when (other) {
+        None, Date, Time, Offset, DateTime, TimeWithOffset, DateTimeWithOffset, DateTimeWithZone -> ZonedDateTime::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveSpellOut() {
+    SpellOut.assertArgumentTypes { other ->
+      when (other) {
+        None, Number, SpellOut -> KotlinNumber::class
+        Choice, Ordinal, Plural, SelectOrdinal -> Int::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveOrdinal() {
+    Ordinal.assertArgumentTypes { other ->
+      when (other) {
+        None, Choice, Number, Ordinal, Plural, SelectOrdinal, SpellOut -> Int::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveDuration() {
+    Duration.assertArgumentTypes { other ->
+      when (other) {
+        None, Duration -> KotlinDuration::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveChoice() {
+    Choice.assertArgumentTypes { other ->
+      when (other) {
+        None, Choice, Number, Ordinal, Plural, SelectOrdinal, SpellOut -> Int::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolvePlural() {
+    Plural.assertArgumentTypes { other ->
+      when (other) {
+        None, Choice, Number, Ordinal, Plural, SelectOrdinal, SpellOut -> Int::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveSelect() {
+    Select.assertArgumentTypes { other ->
+      when (other) {
+        None, Select -> String::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveSelectOrdinal() {
+    SelectOrdinal.assertArgumentTypes { other ->
+      when (other) {
+        None, Choice, Number, Ordinal, Plural, SelectOrdinal, SpellOut -> Int::class
+        else -> null
+      }
+    }
+  }
+
+  @Test
+  fun resolveNoArg() {
+    NoArg.assertArgumentTypes { other ->
+      when (other) {
+        None, NoArg -> Nothing::class
+        else -> null
+      }
+    }
+  }
+
+  private fun TokenType.assertArgumentTypes(expected: (TokenType) -> KClass<*>?) {
+    listOf(this).assertArgumentType(expected(this))
+    TokenType.values().forEach { other ->
+      listOf(this, other).assertArgumentType(expected(other))
+    }
+  }
+
+  private fun List<TokenType>.assertArgumentType(expected: KClass<*>?) =
+    assertThat(resolveArgumentType(tokenTypes = this)).isEqualTo(expected)
+}


### PR DESCRIPTION
There are some situations where a single argument might have multiple types:
```
Your order was placed on {timestamp, date} at {timestamp, time}

{count, plural,
  =1 {You have 1 notification}
  other {You have {count} notifications}
}
```

Our current approach to this is very naive - we just take the first argument type and hope for the best.

We can do better though. We can look through all the token types to try to find an argument type that satisfies them all.

Sometimes we'll choose the more restrictive of of the two input argument types:
- `Date` is normally resolved with `LocalDate`
- `DateTime` is normally resolved with `LocalDateTime`
- We'll resolve the combination with `LocalDateTime`

Sometimes we'll choose a third type that's more restrictive than both input argument types:
- `Date` is normally resolved with `LocalDate`
- `Time` is normally resolved with `LocalTime`
- We'll resolve the combination with `LocalDateTime`

And if there's no acceptable common type we'll omit the argument and report a parsing error.