### PR TITLE
Don't write empty resource files

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/GenerateFormattedResources.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/GenerateFormattedResources.kt
@@ -106,8 +106,10 @@ internal abstract class GenerateFormattedResources @Inject constructor() : Defau
       }
       .filter { it.arguments.isNotEmpty() }
 
-    writeResources(namespace.get(), mergedResources)
-      .writeTo(outputDirectory.get().asFile)
+    if (mergedResources.isNotEmpty()) {
+      writeResources(namespace.get(), mergedResources)
+        .writeTo(outputDirectory.get().asFile)
+    }
 
     // TODO Fail on errors which make it this far.
   }


### PR DESCRIPTION
We did this once before in #28, but then regressed when we moved to a more complicated resource pipeline.

The issue is not just that we're generating an unnecessary empty file - we're throwing a `NoSuchElementException` in `ResourceWriter` here:
```kotlin
val maxVisibility = mergedResources.maxOf { it.visibility }
```