### PR TITLE
Add runtime support for Compose UI

### DIFF
--- a/runtime-compose-ui/build.gradle.kts
+++ b/runtime-compose-ui/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+  alias(libs.plugins.androidLibrary)
+  alias(libs.plugins.kotlinAndroid)
+  alias(libs.plugins.mavenPublish)
+  alias(libs.plugins.dokka)
+}
+
+android {
+  namespace = "app.cash.paraphrase.compose"
+  compileSdk = 33
+
+  buildFeatures {
+    compose = true
+  }
+
+  composeOptions {
+    kotlinCompilerExtensionVersion = libs.versions.compose.compiler.get()
+  }
+
+  defaultConfig {
+    minSdk = 24
+    targetSdk = 33
+  }
+}
+
+dependencies {
+  api(libs.composeUi)
+  api(projects.runtime)
+}

--- a/runtime-compose-ui/gradle.properties
+++ b/runtime-compose-ui/gradle.properties
@@ -1,0 +1,3 @@
+# Maven
+POM_ARTIFACT_ID=paraphrase-runtime-compose-ui
+POM_NAME=Paraphrase runtime for Compose UI

--- a/runtime-compose-ui/src/main/java/app/cash/paraphrase/compose/ComposableFormattedResources.kt
+++ b/runtime-compose-ui/src/main/java/app/cash/paraphrase/compose/ComposableFormattedResources.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2023 Cash App
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.paraphrase.compose
+
+import android.icu.text.MessageFormat
+import android.icu.util.ULocale
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.res.stringResource
+import app.cash.paraphrase.FormattedResource
+import java.util.Locale
+
+/**
+ * Resolves and returns the final formatted version of the given resource in the default locale.
+ */
+@Composable
+@ReadOnlyComposable
+fun formattedResource(formattedResource: FormattedResource): String =
+  MessageFormat(stringResource(formattedResource.id)).format(formattedResource.arguments)
+
+/**
+ * Resolves and returns the final formatted version of the given resource in the given locale.
+ */
+@Composable
+@ReadOnlyComposable
+fun formattedResource(formattedResource: FormattedResource, locale: Locale): String =
+  MessageFormat(stringResource(formattedResource.id), locale).format(formattedResource.arguments)
+
+/**
+ * Resolves and returns the final formatted version of the given resource in the given locale.
+ */
+@Composable
+@ReadOnlyComposable
+fun formattedResource(formattedResource: FormattedResource, locale: ULocale): String =
+  MessageFormat(stringResource(formattedResource.id), locale).format(formattedResource.arguments)

--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -38,6 +38,7 @@ androidComponents {
 }
 
 dependencies {
+  implementation(projects.runtimeComposeUi)
   implementation(projects.sample.library)
   implementation(libs.androidActivityCompose)
   implementation(libs.googleMaterial)

--- a/sample/app/src/main/java/app/cash/paraphrase/sample/app/MainActivity.kt
+++ b/sample/app/src/main/java/app/cash/paraphrase/sample/app/MainActivity.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import app.cash.paraphrase.FormattedResource
-import app.cash.paraphrase.getString
+import app.cash.paraphrase.compose.formattedResource
 import app.cash.paraphrase.sample.app.FormattedResources as AppFormattedResources
 import app.cash.paraphrase.sample.library.FormattedResources as LibraryFormattedResources
 import java.time.LocalDate
@@ -74,7 +74,7 @@ class MainActivity : ComponentActivity() {
       )
 
       Text(
-        text = resources.getString(sample.resource),
+        text = formattedResource(sample.resource),
         fontSize = 16.sp,
       )
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ rootProject.name = "paraphrase"
 include(
   ":plugin",
   ":runtime",
+  ":runtime-compose-ui",
   ":sample:app",
   ":sample:library",
   ":tests",


### PR DESCRIPTION
If you're working with Android views, then you're likely using something in the `Resources.getString(...)` family and Paraphrase provides equivalent extension functions:
```kotlin
// Platform
fun Resources.getString(@StringRes id: Int): String

// Paraphrase
fun Resources.getString(formattedResource: FormattedResource): String
```

But if you're working in Compose UI, then you're likely using `stringResource(...)` and Paraphrase doesn't yet have an equivalent. I'm proposing that we add something like:
```kotlin
// Platform
@Composable
fun stringResource(@StringRes id: Int): String

// Paraphrase
@Composable
fun formattedResource(formattedResource: FormattedResource): String
```