### PR TITLE
Publish unified docs for both runtime modules

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - uses: gradle/gradle-build-action@v2
 
-      - run: ./gradlew :runtime:dokkaHtml publish
+      - run: ./gradlew dokkaHtmlMultiModule publish
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
@@ -68,6 +68,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: site
-          FOLDER: runtime/build/dokka/html
+          FOLDER: build/dokka/htmlMultiModule/
           TARGET_FOLDER: docs/latest/
           CLEAN: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-        run: ./gradlew :runtime:dokkaHtml publish
+        run: ./gradlew dokkaHtmlMultiModule publish
 
       - name: Extract release notes
         id: release_notes
@@ -41,6 +41,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: site
-          FOLDER: runtime/build/dokka/html
+          FOLDER: build/dokka/htmlMultiModule/
           TARGET_FOLDER: 0.x/docs/
           CLEAN: true

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
   alias(libs.plugins.androidTest) apply false
   alias(libs.plugins.kotlinAndroid) apply false
   alias(libs.plugins.kotlinJvm) apply false
-  alias(libs.plugins.dokka) apply false
+  alias(libs.plugins.dokka)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.spotless)
 }


### PR DESCRIPTION
Following up on #149. We now have two runtime modules and want to publish docs for both. So instead of publishing directly from the `runtime` module I'm applying the Dokka plugin to the root module and running the multi-module task from there.

I've tried to mirror the setup in Redwood, but I know very little about Dokka and even less about GitHub Actions - so definitely double check that I haven't missed something!