### PR TITLE
Remove usages of targetSdk from library modules

### DIFF
--- a/runtime-compose-ui/build.gradle.kts
+++ b/runtime-compose-ui/build.gradle.kts
@@ -19,7 +19,6 @@ android {
 
   defaultConfig {
     minSdk = 24
-    targetSdk = 33
   }
 }
 

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -12,7 +12,6 @@ android {
 
   defaultConfig {
     minSdk = 24
-    targetSdk = 33
   }
 }
 

--- a/sample/library/build.gradle.kts
+++ b/sample/library/build.gradle.kts
@@ -11,7 +11,6 @@ android {
 
   defaultConfig {
     minSdk = 24
-    targetSdk = 33
   }
 }
 


### PR DESCRIPTION
It's deprecated (for library modules) in AGP 8 and will be removed in AGP 9. It only affects instrumented tests, and we're not running any instrumented tests in library modules.