### PR TITLE
Use Poko for FormattedResource definition

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,13 +9,13 @@ buildscript {
   }
 }
 
-@Suppress("DSL_SCOPE_VIOLATION", "UnstableApiUsage")
 plugins {
   alias(libs.plugins.androidApplication) apply false
   alias(libs.plugins.androidLibrary) apply false
   alias(libs.plugins.androidTest) apply false
   alias(libs.plugins.kotlinAndroid) apply false
   alias(libs.plugins.kotlinJvm) apply false
+  alias(libs.plugins.poko) apply false
   alias(libs.plugins.dokka)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.spotless)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,5 +30,6 @@ kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version = "1.8.20" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.25.2" }
+poko = { id = "dev.drewhamilton.poko", version = "0.13.1" }
 spotless = { id = "com.diffplug.spotless", version = "6.19.0" }
 kotlinApiDump = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.2" }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.dokka)
   alias(libs.plugins.kotlinApiDump)
+  alias(libs.plugins.poko)
 }
 
 android {

--- a/runtime/src/main/java/app/cash/paraphrase/FormattedResource.kt
+++ b/runtime/src/main/java/app/cash/paraphrase/FormattedResource.kt
@@ -17,6 +17,9 @@ package app.cash.paraphrase
 
 import android.icu.text.MessageFormat
 import androidx.annotation.StringRes
+import dev.drewhamilton.poko.ArrayContentBased
+import dev.drewhamilton.poko.ArrayContentSupport
+import dev.drewhamilton.poko.Poko
 
 /**
  * A [FormattedResource] consists of:
@@ -41,47 +44,9 @@ import androidx.annotation.StringRes
  *
  * @property arguments Arguments passed directly to [MessageFormat.format].
  */
-class FormattedResource constructor(
+@OptIn(ArrayContentSupport::class)
+@Poko
+class FormattedResource(
   @StringRes val id: Int,
-  val arguments: Any,
-) {
-
-  override fun equals(other: Any?): Boolean {
-    if (this === other) return true
-    if (other !is FormattedResource) return false
-
-    return id == other.id &&
-      arguments.flexibleEquals(other.arguments)
-  }
-
-  /**
-   * Returns [Array.contentEquals] if this and [other] are both arrays, otherwise uses `==`.
-   */
-  private fun Any.flexibleEquals(other: Any?): Boolean {
-    return this == other || (this is Array<*> && other is Array<*> && contentEquals(other))
-  }
-
-  override fun hashCode(): Int {
-    var result = id
-    result = 31 * result + arguments.flexibleHashCode()
-    return result
-  }
-
-  /**
-   * Returns [Array.contentHashCode] if this is an array, otherwise [hashCode].
-   */
-  private fun Any.flexibleHashCode(): Int {
-    return if (this is Array<*>) contentHashCode() else hashCode()
-  }
-
-  override fun toString(): String {
-    return "FormattedResource(id=$id, arguments=${arguments.flexibleToString()}"
-  }
-
-  /**
-   * Returns [Array.contentToString] if this is an array, otherwise [toString].
-   */
-  private fun Any.flexibleToString(): String {
-    return if (this is Array<*>) contentToString() else toString()
-  }
-}
+  @ArrayContentBased val arguments: Any,
+)

--- a/runtime/src/test/java/app/cash/paraphrase/FormattedResourceTest.kt
+++ b/runtime/src/test/java/app/cash/paraphrase/FormattedResourceTest.kt
@@ -109,12 +109,12 @@ class FormattedResourceTest {
   //region toString
   @Test fun `toString with map includes contents`() {
     val instance = FormattedResource(id = 123, arguments = mapOf("a" to 1, "b" to 2))
-    assertThat(instance.toString()).isEqualTo("FormattedResource(id=123, arguments={a=1, b=2}")
+    assertThat(instance.toString()).isEqualTo("FormattedResource(id=123, arguments={a=1, b=2})")
   }
 
   @Test fun `toString with array includes contents`() {
     val instance = FormattedResource(id = 123, arguments = arrayOf("a", "b"))
-    assertThat(instance.toString()).isEqualTo("FormattedResource(id=123, arguments=[a, b]")
+    assertThat(instance.toString()).isEqualTo("FormattedResource(id=123, arguments=[a, b])")
   }
   //endregion
 }


### PR DESCRIPTION
[Poko](https://github.com/drewhamilton/Poko) generates `equals`, `hashCode`, and `toString` without generating `copy` or `componentN` functions – i.e. data classes with fewer compatibility headaches. I recently implemented support for [respecting array content](https://github.com/drewhamilton/Poko/issues/1) in the generated functions and I thought it'd be fun to try it out here.

We don't have to merge if we'd rather the handwritten code than the additional dependency. But this did catch a typo in the handwritten `toString`!

If we do want to adopt this, first:
- [x] Remove the opt-in annotation or agree we're OK with it for now
- [x] Use a stable version