### PR TITLE
Add Kotlin API dump plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,3 +31,4 @@ kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version = "1.8.20" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version = "0.25.2" }
 spotless = { id = "com.diffplug.spotless", version = "6.19.0" }
+kotlinApiDump = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.2" }

--- a/runtime-compose-ui/api/runtime-compose-ui.api
+++ b/runtime-compose-ui/api/runtime-compose-ui.api
@@ -1,0 +1,6 @@
+public final class app/cash/paraphrase/compose/ComposableFormattedResourcesKt {
+	public static final fun formattedResource (Lapp/cash/paraphrase/FormattedResource;Landroid/icu/util/ULocale;Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	public static final fun formattedResource (Lapp/cash/paraphrase/FormattedResource;Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+	public static final fun formattedResource (Lapp/cash/paraphrase/FormattedResource;Ljava/util/Locale;Landroidx/compose/runtime/Composer;I)Ljava/lang/String;
+}
+

--- a/runtime-compose-ui/build.gradle.kts
+++ b/runtime-compose-ui/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
   alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.dokka)
+  alias(libs.plugins.kotlinApiDump)
 }
 
 android {

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -1,0 +1,18 @@
+public final class app/cash/paraphrase/FormattedResource {
+	public fun <init> (ILjava/lang/Object;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArguments ()Ljava/lang/Object;
+	public final fun getId ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class app/cash/paraphrase/FormattedResourcesKt {
+	public static final fun getString (Landroid/content/Context;Lapp/cash/paraphrase/FormattedResource;)Ljava/lang/String;
+	public static final fun getString (Landroid/content/Context;Lapp/cash/paraphrase/FormattedResource;Landroid/icu/util/ULocale;)Ljava/lang/String;
+	public static final fun getString (Landroid/content/Context;Lapp/cash/paraphrase/FormattedResource;Ljava/util/Locale;)Ljava/lang/String;
+	public static final fun getString (Landroid/content/res/Resources;Lapp/cash/paraphrase/FormattedResource;)Ljava/lang/String;
+	public static final fun getString (Landroid/content/res/Resources;Lapp/cash/paraphrase/FormattedResource;Landroid/icu/util/ULocale;)Ljava/lang/String;
+	public static final fun getString (Landroid/content/res/Resources;Lapp/cash/paraphrase/FormattedResource;Ljava/util/Locale;)Ljava/lang/String;
+}
+

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
   alias(libs.plugins.kotlinAndroid)
   alias(libs.plugins.mavenPublish)
   alias(libs.plugins.dokka)
+  alias(libs.plugins.kotlinApiDump)
 }
 
 android {


### PR DESCRIPTION
Unfortunately this plugin does not actually validate that changes are compatible so reviewers must still remain vigilant to changes to this file. Obviously we're pre-1.0 so we can tolerate some breaking changes, and this will help make us aware of it.

Long term we deserve something better than this, but this is good enough for now.