### PR TITLE
For Renovate, group Poko with Kotlin updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,10 +5,11 @@
   ],
   "packageRules": [
     {
-      // Compose compiler is tightly coupled to Kotlin version
-      "groupName": "Kotlin and Compose",
+      // Compiler plugins are tightly coupled to Kotlin version
+      "groupName": "Kotlin",
       "matchPackagePrefixes": [
         "androidx.compose.compiler",
+        "dev.drewhamilton.poko",
         "org.jetbrains.kotlin",
       ],
     },


### PR DESCRIPTION
Like any compiler plugin, it often breaks with new Kotlin versions, so Kotlin update PRs will need Poko updates too.