### PR TITLE
Add missing changes to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 Changed:
 
 - Automatically add the `runtime-compose-ui` dependency if buildFeatures.compose is true
+- Add missing `)` to `FormattedResource.toString`
+- Optimize insertion performance of map arguments
 
 ## [0.2.0] - 2023-04-25
 


### PR DESCRIPTION
Wanting to cut 0.2.1 soon; noticed we missed a few changes since 0.2.0. We also bumped to Kotlin 1.9.0, but I don't think that's really noteworthy for us.