### PR TITLE
Delete the output directory before generating new formatted resources

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/GenerateFormattedResources.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/GenerateFormattedResources.kt
@@ -47,6 +47,8 @@ internal abstract class GenerateFormattedResources @Inject constructor() : Defau
 
   @TaskAction
   fun generateFormattedStringResources() {
+    outputDirectory.get().asFile.deleteRecursively()
+
     // Extract the 'values'-style directories from each resource directory.
     val valuesFolders = resourceDirectories.files
       .flatMap { it.listFiles().orEmpty().toList() }


### PR DESCRIPTION
Speculative fix for #204.

When there are ICU string resources in a module, we generate a `FormattedResources` class in the task's output directory. That class is cached as a task output.

When there are no ICU string resources in a module, we skip generating `FormattedResources` and we don't do anything with the output directory at all.

So what can happen is:
- You add an ICU string to a module
- Paraphrase generates a `FormattedResources` class for the ICU string and writes it to the task's output directory
- You remove the ICU string from the module
- Paraphrase does nothing - crucially it does not overwrite or delete the `FormattedResources` file that was previously added

Gradle assumes that the task left that file untouched intentionally, so it still includes it in the cached output of the task. It will restore it even if you clean the module, manually delete the build folder, whatever. You have to do a build with `--no-build-cache` to fix things.

We can fix that by deleting the output directory before running the rest of the task. If we end up generating a new `FormattedResources`, great. If not, the previous `FormattedResources` won't be in the cache.