### PR TITLE
Use Number instead of Int for plural arguments

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ArgumentTypeResolver.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ArgumentTypeResolver.kt
@@ -56,7 +56,7 @@ internal fun resolveArgumentType(tokenTypes: List<TokenType>): KClass<*>? =
   when (resolveCompatibleTokenType(tokenTypes)) {
     null -> null
     None -> Any::class
-    Number, SpellOut -> KotlinNumber::class
+    Number, Plural, SpellOut -> KotlinNumber::class
     Date -> LocalDate::class
     Time -> LocalTime::class
     TimeWithOffset -> OffsetTime::class
@@ -65,7 +65,7 @@ internal fun resolveArgumentType(tokenTypes: List<TokenType>): KClass<*>? =
     DateTimeWithZone -> ZonedDateTime::class
     Offset -> ZoneOffset::class
     Duration -> KotlinDuration::class
-    Choice, Ordinal, Plural, SelectOrdinal -> Int::class
+    Choice, Ordinal, SelectOrdinal -> Int::class
     Select -> String::class
     NoArg -> Nothing::class
   }
@@ -109,11 +109,11 @@ private val compatibleTokenTypes: Map<TokenType, List<TokenType>> = mapOf(
   DateTimeWithZone to emptyList(),
   Offset to listOf(TimeWithOffset, DateTimeWithOffset, DateTimeWithZone),
   SpellOut to listOf(Choice, Number, Ordinal, Plural, SelectOrdinal),
-  Ordinal to listOf(Choice, Plural, SelectOrdinal),
+  Ordinal to listOf(Choice, SelectOrdinal),
   Duration to emptyList(),
-  Choice to listOf(Ordinal, Plural, SelectOrdinal),
-  Plural to listOf(Choice, Ordinal, SelectOrdinal),
+  Choice to listOf(Ordinal, SelectOrdinal),
+  Plural to listOf(Choice, Number, Ordinal, SelectOrdinal, SpellOut),
   Select to emptyList(),
-  SelectOrdinal to listOf(Choice, Ordinal, Plural),
+  SelectOrdinal to listOf(Choice, Ordinal),
   NoArg to emptyList(),
 )

--- a/plugin/src/test/java/app/cash/paraphrase/plugin/ArgumentTypeResolverTest.kt
+++ b/plugin/src/test/java/app/cash/paraphrase/plugin/ArgumentTypeResolverTest.kt
@@ -62,8 +62,8 @@ class ArgumentTypeResolverTest {
   fun resolveNumber() {
     Number.assertArgumentTypes { other ->
       when (other) {
-        None, Number, SpellOut -> KotlinNumber::class
-        Choice, Ordinal, Plural, SelectOrdinal -> Int::class
+        None, Number, Plural, SpellOut -> KotlinNumber::class
+        Choice, Ordinal, SelectOrdinal -> Int::class
         else -> null
       }
     }
@@ -158,8 +158,8 @@ class ArgumentTypeResolverTest {
   fun resolveSpellOut() {
     SpellOut.assertArgumentTypes { other ->
       when (other) {
-        None, Number, SpellOut -> KotlinNumber::class
-        Choice, Ordinal, Plural, SelectOrdinal -> Int::class
+        None, Number, Plural, SpellOut -> KotlinNumber::class
+        Choice, Ordinal, SelectOrdinal -> Int::class
         else -> null
       }
     }
@@ -199,7 +199,8 @@ class ArgumentTypeResolverTest {
   fun resolvePlural() {
     Plural.assertArgumentTypes { other ->
       when (other) {
-        None, Choice, Number, Ordinal, Plural, SelectOrdinal, SpellOut -> Int::class
+        None, Number, Plural, SpellOut -> KotlinNumber::class
+        Choice, Ordinal, SelectOrdinal -> Int::class
         else -> null
       }
     }


### PR DESCRIPTION
Currently we require `Int` for plural arguments, but the underlying ICU library supports formatting with `Long`, `Double`, etc.

There are plenty of use cases where this is valid, so it should be supported by Paraphrase. For example:
```
{length, plural,
  one {The race is 1 mile long}
  other {The race is # miles long}
}

// The race is 26.2 miles long
```

Partially addresses #207