### PR TITLE
Use Number instead of Int for choice arguments

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ArgumentTypeResolver.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ArgumentTypeResolver.kt
@@ -56,7 +56,7 @@ internal fun resolveArgumentType(tokenTypes: List<TokenType>): KClass<*>? =
   when (resolveCompatibleTokenType(tokenTypes)) {
     null -> null
     None -> Any::class
-    Number, Plural, SpellOut -> KotlinNumber::class
+    Choice, Number, Plural, SpellOut -> KotlinNumber::class
     Date -> LocalDate::class
     Time -> LocalTime::class
     TimeWithOffset -> OffsetTime::class
@@ -65,7 +65,7 @@ internal fun resolveArgumentType(tokenTypes: List<TokenType>): KClass<*>? =
     DateTimeWithZone -> ZonedDateTime::class
     Offset -> ZoneOffset::class
     Duration -> KotlinDuration::class
-    Choice, Ordinal, SelectOrdinal -> Int::class
+    Ordinal, SelectOrdinal -> Int::class
     Select -> String::class
     NoArg -> Nothing::class
   }
@@ -109,11 +109,11 @@ private val compatibleTokenTypes: Map<TokenType, List<TokenType>> = mapOf(
   DateTimeWithZone to emptyList(),
   Offset to listOf(TimeWithOffset, DateTimeWithOffset, DateTimeWithZone),
   SpellOut to listOf(Choice, Number, Ordinal, Plural, SelectOrdinal),
-  Ordinal to listOf(Choice, SelectOrdinal),
+  Ordinal to listOf(SelectOrdinal),
   Duration to emptyList(),
-  Choice to listOf(Ordinal, SelectOrdinal),
+  Choice to listOf(Number, Ordinal, Plural, SelectOrdinal, SpellOut),
   Plural to listOf(Choice, Number, Ordinal, SelectOrdinal, SpellOut),
   Select to emptyList(),
-  SelectOrdinal to listOf(Choice, Ordinal),
+  SelectOrdinal to listOf(Ordinal),
   NoArg to emptyList(),
 )

--- a/plugin/src/test/java/app/cash/paraphrase/plugin/ArgumentTypeResolverTest.kt
+++ b/plugin/src/test/java/app/cash/paraphrase/plugin/ArgumentTypeResolverTest.kt
@@ -62,8 +62,8 @@ class ArgumentTypeResolverTest {
   fun resolveNumber() {
     Number.assertArgumentTypes { other ->
       when (other) {
-        None, Number, Plural, SpellOut -> KotlinNumber::class
-        Choice, Ordinal, SelectOrdinal -> Int::class
+        None, Choice, Number, Plural, SpellOut -> KotlinNumber::class
+        Ordinal, SelectOrdinal -> Int::class
         else -> null
       }
     }
@@ -158,8 +158,8 @@ class ArgumentTypeResolverTest {
   fun resolveSpellOut() {
     SpellOut.assertArgumentTypes { other ->
       when (other) {
-        None, Number, Plural, SpellOut -> KotlinNumber::class
-        Choice, Ordinal, SelectOrdinal -> Int::class
+        None, Choice, Number, Plural, SpellOut -> KotlinNumber::class
+        Ordinal, SelectOrdinal -> Int::class
         else -> null
       }
     }
@@ -189,7 +189,8 @@ class ArgumentTypeResolverTest {
   fun resolveChoice() {
     Choice.assertArgumentTypes { other ->
       when (other) {
-        None, Choice, Number, Ordinal, Plural, SelectOrdinal, SpellOut -> Int::class
+        None, Choice, Number, Plural, SpellOut -> KotlinNumber::class
+        Ordinal, SelectOrdinal -> Int::class
         else -> null
       }
     }
@@ -199,8 +200,8 @@ class ArgumentTypeResolverTest {
   fun resolvePlural() {
     Plural.assertArgumentTypes { other ->
       when (other) {
-        None, Number, Plural, SpellOut -> KotlinNumber::class
-        Choice, Ordinal, SelectOrdinal -> Int::class
+        None, Choice, Number, Plural, SpellOut -> KotlinNumber::class
+        Ordinal, SelectOrdinal -> Int::class
         else -> null
       }
     }


### PR DESCRIPTION
Similar to #215. The underlying ICU library supports decimal numbers for `choice` arguments, so we should too.
```
{0, choice, 0#Zero | 0.5#Half | 1<{0,number}}
```

The official documentation [discourages](https://unicode-org.github.io/icu/userguide/format_parse/messages/#complex-argument-types) the use of `choice` arguments in favor of `plural`, `select`, etc so in practice people shouldn't hit this too often. But it's an easy fix so why not.

Partially addresses #207.