### PR TITLE
Generate Long parameters for ordinal arguments

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ArgumentTypeResolver.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ArgumentTypeResolver.kt
@@ -65,7 +65,7 @@ internal fun resolveArgumentType(tokenTypes: List<TokenType>): KClass<*>? =
     DateTimeWithZone -> ZonedDateTime::class
     Offset -> ZoneOffset::class
     Duration -> KotlinDuration::class
-    Ordinal, SelectOrdinal -> Int::class
+    Ordinal, SelectOrdinal -> Long::class
     Select -> String::class
     NoArg -> Nothing::class
   }

--- a/plugin/src/test/java/app/cash/paraphrase/plugin/ArgumentTypeResolverTest.kt
+++ b/plugin/src/test/java/app/cash/paraphrase/plugin/ArgumentTypeResolverTest.kt
@@ -63,7 +63,7 @@ class ArgumentTypeResolverTest {
     Number.assertArgumentTypes { other ->
       when (other) {
         None, Choice, Number, Plural, SpellOut -> KotlinNumber::class
-        Ordinal, SelectOrdinal -> Int::class
+        Ordinal, SelectOrdinal -> Long::class
         else -> null
       }
     }
@@ -159,7 +159,7 @@ class ArgumentTypeResolverTest {
     SpellOut.assertArgumentTypes { other ->
       when (other) {
         None, Choice, Number, Plural, SpellOut -> KotlinNumber::class
-        Ordinal, SelectOrdinal -> Int::class
+        Ordinal, SelectOrdinal -> Long::class
         else -> null
       }
     }
@@ -169,7 +169,7 @@ class ArgumentTypeResolverTest {
   fun resolveOrdinal() {
     Ordinal.assertArgumentTypes { other ->
       when (other) {
-        None, Choice, Number, Ordinal, Plural, SelectOrdinal, SpellOut -> Int::class
+        None, Choice, Number, Ordinal, Plural, SelectOrdinal, SpellOut -> Long::class
         else -> null
       }
     }
@@ -190,7 +190,7 @@ class ArgumentTypeResolverTest {
     Choice.assertArgumentTypes { other ->
       when (other) {
         None, Choice, Number, Plural, SpellOut -> KotlinNumber::class
-        Ordinal, SelectOrdinal -> Int::class
+        Ordinal, SelectOrdinal -> Long::class
         else -> null
       }
     }
@@ -201,7 +201,7 @@ class ArgumentTypeResolverTest {
     Plural.assertArgumentTypes { other ->
       when (other) {
         None, Choice, Number, Plural, SpellOut -> KotlinNumber::class
-        Ordinal, SelectOrdinal -> Int::class
+        Ordinal, SelectOrdinal -> Long::class
         else -> null
       }
     }
@@ -221,7 +221,7 @@ class ArgumentTypeResolverTest {
   fun resolveSelectOrdinal() {
     SelectOrdinal.assertArgumentTypes { other ->
       when (other) {
-        None, Choice, Number, Ordinal, Plural, SelectOrdinal, SpellOut -> Int::class
+        None, Choice, Number, Ordinal, Plural, SelectOrdinal, SpellOut -> Long::class
         else -> null
       }
     }

--- a/tests/src/main/kotlin/app/cash/paraphrase/tests/TypesTest.kt
+++ b/tests/src/main/kotlin/app/cash/paraphrase/tests/TypesTest.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.paraphrase.tests
 
+import android.os.Build
 import androidx.test.platform.app.InstrumentationRegistry
 import app.cash.paraphrase.getString
 import com.google.common.truth.Truth.assertThat
@@ -324,6 +325,14 @@ class TypesTest {
     assertThat(formattedThree).isEqualTo("A 3rd B")
     val formattedFour = context.getString(FormattedResources.type_ordinal(4))
     assertThat(formattedFour).isEqualTo("A 4th B")
+    val formattedLong = context.getString(FormattedResources.type_ordinal(Long.MAX_VALUE))
+    val expected = if (Build.VERSION.SDK_INT >= 26) {
+      "9,223,372,036,854,775,807th"
+    } else {
+      // ICU versions on older Android platforms lose bits by internally converting Long to Double:
+      "9,223,372,036,854,776,000th"
+    }
+    assertThat(formattedLong).isEqualTo("A $expected B")
   }
 
   @Test fun typeSpellout() {


### PR DESCRIPTION
Converts the param type used for `ordinal` and `selectordinal` arguments from `Int` to `Long`. See discussion in #207.