### PR TITLE
Generate Int overload for Long parameters

### DIFF
--- a/tests/src/main/kotlin/app/cash/paraphrase/tests/TypesTest.kt
+++ b/tests/src/main/kotlin/app/cash/paraphrase/tests/TypesTest.kt
@@ -315,7 +315,8 @@ class TypesTest {
   }
 
   @Test fun typeOrdinal() {
-    val formattedZero = context.getString(FormattedResources.type_ordinal(0))
+    val zero = 0 // Requires an int overload to be invoked
+    val formattedZero = context.getString(FormattedResources.type_ordinal(zero))
     assertThat(formattedZero).isEqualTo("A 0th B")
     val formattedOne = context.getString(FormattedResources.type_ordinal(1))
     assertThat(formattedOne).isEqualTo("A 1st B")


### PR DESCRIPTION
Closes #207.

While `Long` is the technically correct type for `ordinal` arguments, it's more common to want to format an `Int` as an ordinal. With this PR, Paraphrase generates an inline overload for all generated functions that contain at least one `Long` parameter, replacing each `Long` with `Int` in the overload.

So if this is generated:
```kotlin
public fun type_ordinal(`value`: Long): FormattedResource {
  val arguments = ArrayMap<String, Any>(1)
  arguments.put(
    "value",
    value,
  )
  return FormattedResource(
    id = R.string.type_ordinal,
    arguments = arguments,
  )
}
```

Now this overload is also generated:
```kotlin
public inline fun type_ordinal(`value`: Int): FormattedResource = type_ordinal(
  value.toLong(),
)
```