### PR TITLE
Bump CI to JDK 21

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3.13.0
         with:
           distribution: 'zulu'
-          java-version: 19
+          java-version: 21
 
       - uses: gradle/gradle-build-action@v2
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v3.13.0
         with:
           distribution: 'zulu'
-          java-version: 19
+          java-version: 21
 
       - uses: gradle/gradle-build-action@v2
 
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/setup-java@v3.13.0
         with:
           distribution: 'zulu'
-          java-version: 19
+          java-version: 21
 
       - uses: gradle/gradle-build-action@v2
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v3.13.0
         with:
           distribution: 'zulu'
-          java-version: 19
+          java-version: 21
 
       - name: Build and publish artifacts
         env:


### PR DESCRIPTION
Gradle's [compatibility matrix](https://docs.gradle.org/current/userguide/compatibility.html#java) says that Java 21 can't be used to execute Gradle 8.4. But it seems to work fine.