### PR TITLE
Suppress inline warning on generated `Int` overload

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceWriter.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ResourceWriter.kt
@@ -239,6 +239,11 @@ private fun MergedResource.toIntOverloadFunSpec(overloaded: FunSpec): FunSpec {
   return FunSpec.builder(name.value)
     .apply {
       if (description != null) addKdoc(description)
+      addAnnotation(
+        annotationSpec = AnnotationSpec.builder(Suppress::class)
+          .addMember("%S", "NOTHING_TO_INLINE")
+          .build(),
+      )
       arguments.forEach { argument ->
         val parameterSpec = if (argument.type == Long::class) {
           ParameterSpec(


### PR DESCRIPTION
I included the `inline` modifier in the overload added in #236, to guarantee there is no extra cost to calling the overload. But that produced a warning the consumer can't do anything about, so this suppresses that warning.

To the Kotlin compiler's point, this inlines a very inexpensive operation, so it's not really necessary. Just felt like a good idea to make it free.