### PR TITLE
Enable -Werror for sample app

### DIFF
--- a/sample/app/build.gradle.kts
+++ b/sample/app/build.gradle.kts
@@ -27,6 +27,10 @@ android {
   compileOptions {
     isCoreLibraryDesugaringEnabled = true
   }
+
+  kotlinOptions {
+    allWarningsAsErrors = true
+  }
 }
 
 androidComponents {

--- a/sample/app/src/main/java/app/cash/paraphrase/sample/app/MainActivity.kt
+++ b/sample/app/src/main/java/app/cash/paraphrase/sample/app/MainActivity.kt
@@ -143,6 +143,7 @@ class MainActivity : ComponentActivity() {
         label = "Select Ordinal Argument",
         resource = LibraryFormattedResources.library_select_ordinal_argument(count = 5),
       ),
+      @Suppress("DEPRECATION")
       Sample(
         label = "Choice argument",
         resource = LibraryFormattedResources.library_choice_argument(outlook = 100),


### PR DESCRIPTION
This ensures that any warnings produced by Paraphrase—which consumers cannot address—will fail the build.

I can't currently add it to tests because when we produce a `Nothing?` parameter, that parameter is unused. I'm not sure we want to suppress this, because `Nothing?` parameters indicate a likely mistake: The consumer has marked an argument as a date/time, but included only literal characters in the pattern.

More generally it's plausible that Paraphrase wants to generate warnings intentionally in some cases, so probably `sample` is the best place for this.