### PR TITLE
Use 'use' to ensure stream is closed

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/GenerateFormattedResources.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/GenerateFormattedResources.kt
@@ -121,7 +121,7 @@ internal abstract class GenerateFormattedResources @Inject constructor() : Defau
 
   private fun <T> File.checkedRead(parser: (InputStream) -> T): T {
     return try {
-      inputStream().buffered().run(parser)
+      inputStream().buffered().use(parser)
     } catch (e: Exception) {
       throw IllegalArgumentException("Unable to parse $this", e)
     }


### PR DESCRIPTION
I had switched to `run` when testing out the generics and forgot to switch back. Whooooops.