### PR TITLE
Don't try to parse non-XML files

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/GenerateFormattedResources.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/GenerateFormattedResources.kt
@@ -63,7 +63,10 @@ internal abstract class GenerateFormattedResources @Inject constructor() : Defau
     //   values-es -> [strings.xml]
     val filesByConfiguration = valuesFolders
       .associate { folder ->
-        ResourceFolder(folder.name) to folder.listFiles().orEmpty().toList()
+        ResourceFolder(folder.name) to folder.listFiles()
+          .orEmpty()
+          .filter { it.extension.equals("xml", ignoreCase = true) }
+          .toList()
       }
 
     // Parse the files in each folder into the tokenized resources.


### PR DESCRIPTION
Paraphrase throws an exception if there are `.DS_Store` files in your `values` directories:
```
> Task :sample:app:generateFormattedResourcesDebug FAILED
[Fatal Error] :1:1: Content is not allowed in prolog.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':sample:app:generateFormattedResourcesDebug'.
> Unable to parse /Users/ptheisen/Development/paraphrase/sample/app/src/main/res/values/.DS_Store
```

More generally it fails if there are _any_ non-XML files in your `values` directories. It tries to parse them as XML and then throws an exception. We can fix that by excluding non-XML files from our parsing.

We could also consider catching exceptions like this and ignoring them. If the rest of the build doesn't fail then maybe Paraphrase shouldn't either? But I'm fine punting on that until we have a real world use case.