### PR TITLE
Remove unused UnstableApiUsage suppression

### DIFF
--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ParaphrasePlugin.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ParaphrasePlugin.kt
@@ -27,7 +27,6 @@ import org.gradle.configurationcache.extensions.capitalized
 /**
  * A Gradle plugin that generates type checked formatters for patterned Android string resources.
  */
-@Suppress("UnstableApiUsage") // For 'Sources' type.
 public class ParaphrasePlugin : Plugin<Project> {
   override fun apply(target: Project): Unit = target.run {
     addDependencies()


### PR DESCRIPTION
It looks like we no longer need to suppress `UnstableApiUsage` for Gradle's `Sources` type