### PR TITLE
Bump minimum-supported Gradle version to 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Change Log
 
 ## [Unreleased]
-[Unreleased]: https://github.com/cashapp/paraphrase/compare/0.4.0...HEAD
+[Unreleased]: https://github.com/cashapp/paraphrase/compare/0.4.1...HEAD
 
-Nothing yet.
+Changed:
+
+- The minimum-supported Gradle version is now 9.0.
 
 
 ## [0.4.1] - 2025-09-12

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -34,16 +34,16 @@ tasks.named("validatePlugins", ValidatePlugins::class) {
 
 tasks.withType<KotlinJvmCompile> {
   compilerOptions {
-    jvmTarget = JvmTarget.JVM_11
+    jvmTarget = JvmTarget.JVM_17
     // Ensure compatibility with older Gradle versions. Keep in sync with ParaphrasePlugin.kt.
-    apiVersion = KotlinVersion.KOTLIN_1_8
-    languageVersion = KotlinVersion.KOTLIN_1_8
+    apiVersion = KotlinVersion.KOTLIN_2_2
+    languageVersion = KotlinVersion.KOTLIN_2_2
   }
 }
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
 }
 
 dependencies {

--- a/plugin/src/main/java/app/cash/paraphrase/plugin/ParaphrasePlugin.kt
+++ b/plugin/src/main/java/app/cash/paraphrase/plugin/ParaphrasePlugin.kt
@@ -31,7 +31,7 @@ public class ParaphrasePlugin : Plugin<Project> {
   override fun apply(target: Project): Unit = target.run {
     // If you update the minimum-supported Gradle version, check if the Kotlin api/language version
     // can be bumped. See https://docs.gradle.org/current/userguide/compatibility.html#kotlin.
-    val gradleMinimum = GradleVersion.version("8.0")
+    val gradleMinimum = GradleVersion.version("9.0")
     val gradleCurrent = GradleVersion.current()
     require(gradleCurrent >= gradleMinimum) {
       "Plugin requires $gradleMinimum or newer. Found $gradleCurrent"


### PR DESCRIPTION
This allows us to use Kotlin 2.2 and Java 17. The forthcoming Kotlin 2.3.0 will no longer support compiling to 1.8, so we must bump.

Closes #570 