### PR TITLE
Bump minSdk to 26

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Run integration tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 24
+          api-level: 26
           script: ./gradlew :tests:connectedCheck
 
   publish:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,7 @@ subprojects {
     Action<Plugin<Any>> {
       with(extensions.getByType<CommonExtension>()) {
         compileSdk = 36
-        defaultConfig.minSdk = 24
+        defaultConfig.minSdk = 26
 
         compileOptions.apply {
           sourceCompatibility = javaVersion


### PR DESCRIPTION
The FormattedResources this plugin generates uses API 26 methods so we should keep this in line.
```
Call requires API level 26, or core library desugaring (current min is 24): java.time.LocalDate#getDayOfMonth
```

> this is related to the upcoming https://github.com/cashapp/paraphrase/pull/681 change.